### PR TITLE
Fix regexp simulation for AWS platform

### DIFF
--- a/platforms/aws-f1/regexp/verif/scripts/top_verilog.vivado.f
+++ b/platforms/aws-f1/regexp/verif/scripts/top_verilog.vivado.f
@@ -31,10 +31,13 @@
 --include ${HDK_COMMON_DIR}/verif/include
 --include ${SH_LIB_DIR}/../ip/cl_axi_interconnect/ipshared/7e3a/hdl
 --include ${HDK_SHELL_DESIGN_DIR}/sh_ddr/sim
+--include ${HDK_SHELL_DESIGN_DIR}/ip/axi_register_slice_light/hdl
 
 ${SH_LIB_DIR}/../ip/axi_clock_converter_0/sim/axi_clock_converter_0.v
 ${SH_LIB_DIR}/../ip/axi_register_slice/sim/axi_register_slice.v
 ${SH_LIB_DIR}/../ip/axi_register_slice_light/sim/axi_register_slice_light.v
+${HDK_SHELL_DESIGN_DIR}/ip/axi_register_slice_light/hdl/axi_register_slice_v2_1_vl_rfs.v
+${HDK_SHELL_DESIGN_DIR}/ip/axi_clock_converter_0/hdl/axi_clock_converter_v2_1_vl_rfs.v
 
 # Top level interconnect between PCI Slave and DDR C
 ${CL_ROOT}/design/ip/axi_interconnect_top/sim/axi_interconnect_top.v

--- a/platforms/aws-f1/regexp/verif/scripts/top_vhdl.vivado.f
+++ b/platforms/aws-f1/regexp/verif/scripts/top_vhdl.vivado.f
@@ -4,6 +4,9 @@ ${FLETCHER_HARDWARE_DIR}/vhdl/utils/Utils.vhd
 ${FLETCHER_HARDWARE_DIR}/vhdl/utils/SimUtils.vhd
 ${FLETCHER_HARDWARE_DIR}/vhdl/utils/Ram1R1W.vhd
 
+${FLETCHER_HARDWARE_DIR}/vhdl/buffers/Buffers.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/interconnect/Interconnect.vhd
+
 ${FLETCHER_HARDWARE_DIR}/vhdl/streams/Streams.vhd
 ${FLETCHER_HARDWARE_DIR}/vhdl/streams/StreamArb.vhd
 ${FLETCHER_HARDWARE_DIR}/vhdl/streams/StreamBuffer.vhd
@@ -16,30 +19,33 @@ ${FLETCHER_HARDWARE_DIR}/vhdl/streams/StreamSerializer.vhd
 ${FLETCHER_HARDWARE_DIR}/vhdl/streams/StreamSlice.vhd
 ${FLETCHER_HARDWARE_DIR}/vhdl/streams/StreamSync.vhd
 
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderConfigParse.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderConfig.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnConfigParse.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnConfig.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/Columns.vhd
+
 ${FLETCHER_HARDWARE_DIR}/vhdl/arrow/Arrow.vhd
 
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BufferReaderCmdGenBusReq.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BufferReaderCmd.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BufferReaderPost.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BufferReaderRespCtrl.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BufferReaderResp.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BufferReader.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BusReadArbiter.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BusReadArbiterVec.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/BusReadBuffer.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/buffers/BufferReaderCmdGenBusReq.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/buffers/BufferReaderCmd.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/buffers/BufferReaderPost.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/buffers/BufferReaderRespCtrl.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/buffers/BufferReaderResp.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/buffers/BufferReader.vhd
 
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderArb.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderLevel.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderList.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderListPrim.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderListSync.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderListSyncDecoder.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderNull.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderStruct.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReaderUnlockCombine.vhd
-${FLETCHER_HARDWARE_DIR}/vhdl/arrow/ColumnReader.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/interconnect/BusReadArbiter.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/interconnect/BusReadArbiterVec.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/interconnect/BusReadBuffer.vhd
+
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderArb.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderLevel.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderList.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderListPrim.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderListSync.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderListSyncDecoder.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderNull.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderStruct.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReaderUnlockCombine.vhd
+${FLETCHER_HARDWARE_DIR}/vhdl/columns/ColumnReader.vhd
 
 # Files belonging to the RegExp example:
 ${FLETCHER_EXAMPLES_DIR}/regexp/hardware/axi_read_converter.vhd


### PR DESCRIPTION
Change additional path names to #31 and add required Verilog source files for AXI.

````
[platforms/aws-f1/regexp/verif/scripts]$ make TEST=test_regexp
[...]
Read request from MMIO: 1 value -65536
[t] : UserCore status: ffff0000
[            41412000] : UserCore completed
Read request from MMIO: 4 value 0
[t] : Return register HI:           0
Read request from MMIO: 5 value 0
[t] : Return register LO:           0
Read request from MMIO: 42 value 0
[t] : Result regexp           0:           0
Read request from MMIO: 43 value 0
[t] : Result regexp           1:           0
Read request from MMIO: 44 value 0
[t] : Result regexp           2:           0
Read request from MMIO: 45 value 0
[t] : Result regexp           3:           0
Read request from MMIO: 46 value 0
[t] : Result regexp           4:           0
Read request from MMIO: 47 value 0
[t] : Result regexp           5:           0
Read request from MMIO: 48 value 0
[t] : Result regexp           6:           0
Read request from MMIO: 49 value 0
[t] : Result regexp           7:           0
Read request from MMIO: 50 value 0
[t] : Result regexp           8:           0
Read request from MMIO: 51 value 22
[t] : Result regexp           9:          22
Read request from MMIO: 52 value 0
[t] : Result regexp          10:           0
Read request from MMIO: 53 value 0
[t] : Result regexp          11:           0
Read request from MMIO: 54 value 0
[t] : Result regexp          12:           0
Read request from MMIO: 55 value 0
[t] : Result regexp          13:           0
Read request from MMIO: 56 value 0
[t] : Result regexp          14:           0
Read request from MMIO: 57 value 0
[t] : Result regexp          15:           0
[            42404000] : Checking total error count...
[            42404000] : Detected   0 errors during this test
[            42404000] : Checking protocol checker error status...
[            42404000] : *** TEST PASSED ***
[...]
````