### PR TITLE
Update runtime library and usercore to fletchgen register layout

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -103,4 +103,5 @@ endif ()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)
 
-install(DIRECTORY src DESTINATION include)
+install(DIRECTORY src/ DESTINATION include/fletcher
+    FILES_MATCHING PATTERN "*.h")

--- a/runtime/src/FPGAPlatform.cpp
+++ b/runtime/src/FPGAPlatform.cpp
@@ -48,7 +48,8 @@ uint64_t FPGAPlatform::prepare_column_chunks(const std::shared_ptr<arrow::Column
 
   size_t nbufs = host_bufs.size();
 
-  this->_argument_offset += nbufs;
+  // Each buffer address uses two 32-bit registers
+  this->_argument_offset += nbufs * 2;
 
   LOGD("Configured " << nbufs << " buffers. " "Argument offset starting at " << this->argument_offset());
 

--- a/runtime/src/FPGAPlatform.h
+++ b/runtime/src/FPGAPlatform.h
@@ -23,22 +23,26 @@
 #include "common.h"
 
 /// The status register and bits
-#define UC_REG_STATUS   0
+#define UC_REG_STATUS   1
 #define   UC_REG_STATUS_IDLE 0
 #define   UC_REG_STATUS_BUSY 1
 #define   UC_REG_STATUS_DONE 2
 
 /// The control register
-#define UC_REG_CONTROL  1
-#define   UC_REG_CONTROL_RESET 0
-#define   UC_REG_CONTROL_START 1
-#define   UC_REG_CONTROL_STOP  2
+#define UC_REG_CONTROL  0
+#define   UC_REG_CONTROL_START 0
+#define   UC_REG_CONTROL_STOP  1
+#define   UC_REG_CONTROL_RESET 2
 
 /// The return register
-#define UC_REG_RETURN   2
+#define UC_REG_RETURN 2
+
+/// The index of the first and last row
+#define UC_REG_INDEX_FIRST 4
+#define UC_REG_INDEX_LAST  5
 
 /// The offset of the buffer addresses
-#define UC_REG_BUFFERS  3
+#define UC_REG_BUFFERS  6
 
 namespace fletcher {
 
@@ -57,13 +61,13 @@ class FPGAPlatform
   virtual ~FPGAPlatform()=default;
 
   /**
-   * \brief Write a 64-bit value to a memory mapped slave register at 
+   * \brief Write a 32-bit value to a memory mapped slave register at 
    * some offset (address).
    */
   virtual int write_mmio(uint64_t offset, fr_t value)=0;
 
   /**
-   * \brief Read a 64-bit value from a memory mapped slave register at
+   * \brief Read a 32-bit value from a memory mapped slave register at
    * some offset (address) and store it in dest
    */
   virtual int read_mmio(uint64_t offset, fr_t* dest)=0;

--- a/runtime/src/UserCore.cpp
+++ b/runtime/src/UserCore.cpp
@@ -64,7 +64,7 @@ fa_t UserCore::get_return() {
   {
     ret = ret << (sizeof(fr_t) * 8);
     _platform->read_mmio(UC_REG_RETURN + a, &reg_val);
-    ret |= reg_val;
+    ret |= (fa_t) reg_val;
   }
   return ret;
 }

--- a/runtime/src/UserCore.cpp
+++ b/runtime/src/UserCore.cpp
@@ -55,9 +55,17 @@ fr_t UserCore::get_status() {
   return ret;
 }
 
-fr_t UserCore::get_return() {
-  fr_t ret = 0xDEAFBEEF;
-  _platform->read_mmio(UC_REG_RETURN, &ret);
+fa_t UserCore::get_return() {
+  fr_t reg_val = 0xDEAFBEEF;
+  fa_t ret = 0;
+
+  // Fetch multiple registers, assuming big endian order
+  for (int a = (sizeof(fa_t) / sizeof(fr_t)) - 1; a >= 0; a--)
+  {
+    ret = ret << (sizeof(fr_t) * 8);
+    _platform->read_mmio(UC_REG_RETURN + a, &reg_val);
+    ret |= reg_val;
+  }
   return ret;
 }
 

--- a/runtime/src/UserCore.h
+++ b/runtime/src/UserCore.h
@@ -71,7 +71,7 @@ class UserCore {
   /**
    * \brief Read the result register of the UserCore
    */
-  fr_t get_return();
+  fa_t get_return();
 
   /**
    * \brief  A blocking function that waits for the UserCore to finish

--- a/runtime/src/aws/aws.cpp
+++ b/runtime/src/aws/aws.cpp
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <omp.h>
+#include <assert.h>
 
 #include <arrow/api.h>
 
@@ -169,7 +170,7 @@ uint64_t AWSPlatform::organize_buffers(const std::vector<BufConfig> &source_buff
 
     // First buffer goes to address 0 for now
     // TODO: manage memory on on-board DDR
-    uint64_t address = 0x0;
+    fa_t address = 0x0;
 
     for (unsigned int i = 0; i < source_buffers.size(); i++) {
       BufConfig source_buf = source_buffers[i];
@@ -208,7 +209,14 @@ uint64_t AWSPlatform::organize_buffers(const std::vector<BufConfig> &source_buff
 #endif
 
       // Set the buffer address in the MMSRs:
-      write_mmio(UC_REG_BUFFERS + i, (fr_t) dest_buf.address);
+      assert(sizeof(fr_t) == 4);
+      assert(sizeof(fa_t) == 8);
+      write_mmio(
+          UC_REG_BUFFERS + i * 2,
+          (fr_t) (dest_buf.address & 0xffffffff));
+      write_mmio(
+          UC_REG_BUFFERS + i * 2 + 1,
+          (fr_t) ((dest_buf.address >> 32) & 0xffffffff));
 
       dest_buffers.push_back(dest_buf);
 
@@ -235,17 +243,12 @@ uint64_t AWSPlatform::organize_buffers(const std::vector<BufConfig> &source_buff
 int AWSPlatform::write_mmio(uint64_t offset, fr_t value) {
   if (!error) {
     int rc = 0;
-    reg_conv_t conv_value;
-    conv_value.full = value;
 
-    LOGD("[AWSPlatform] AWS fpga_pci_poke " << STRHEX32 << conv_value.half.hi << std::dec << " to reg " << (2 * offset)
-                                            << " addr " << STRHEX64 << (4 * (2 * offset)));
-    LOGD("[AWSPlatform] AWS fpga_pci_poke " << STRHEX32 << conv_value.half.lo << std::dec << " to reg "
-                                            << (2 * offset + 1) << " addr " << STRHEX64 << (4 * (2 * offset + 1)));
+    LOGD("[AWSPlatform] AWS fpga_pci_poke " 
+        << STRHEX32 << value << std::dec << " to reg " << (offset)
+        << " addr " << STRHEX64 << (sizeof(fr_t) * offset));
 
-    rc |= fpga_pci_poke(pci_bar_handle, 4 * (2 * offset), conv_value.half.hi);
-
-    rc |= fpga_pci_poke(pci_bar_handle, 4 * (2 * offset + 1), conv_value.half.lo);
+    rc = fpga_pci_poke(pci_bar_handle, sizeof(fr_t) * offset, value);
 
     // We can't write MMIO
     if (rc != 0) {
@@ -259,27 +262,18 @@ int AWSPlatform::write_mmio(uint64_t offset, fr_t value) {
 int AWSPlatform::read_mmio(uint64_t offset, fr_t *dest) {
   if (!error) {
     int rc = 0;
-    reg_conv_t conv_value;
-    uint32_t ret = 0xDEADBEEF;
 
-    rc |= fpga_pci_peek(pci_bar_handle, 4 * (2 * offset), &ret);
-    conv_value.half.hi = ret;
+    rc = fpga_pci_peek(pci_bar_handle, sizeof(fr_t) * offset, dest);
 
-    LOGD("[AWSPlatform] AWS fpga_pci_peek " << STRHEX32 << ret << " from reg " << std::dec << (2 * offset) << " addr "
-                                            << 4 * (2 * offset));
-
-    rc |= fpga_pci_peek(pci_bar_handle, 4 * (2 * offset + 1), &ret);
-    conv_value.half.lo = ret;
-
-    LOGD("[AWSPlatform] AWS fpga_pci_peek " << STRHEX32 << ret << " from reg " << std::dec << (2 * offset + 1)
-                                            << " addr " << 4 * (2 * offset + 1));
+    LOGD("[AWSPlatform] AWS fpga_pci_peek "
+        << STRHEX32 << ret << " from reg " << std::dec << offset
+        << " addr " << STRHEX64 << (sizeof(fr_t) * offset));
 
     if (rc != 0) {
       LOGD("[AWSPlatform] MMIO read failed.");
       return fletcher::ERROR;
     }
 
-    *dest = conv_value.full;
     return fletcher::OK;
   } else {
     return fletcher::ERROR;

--- a/runtime/src/aws/aws.cpp
+++ b/runtime/src/aws/aws.cpp
@@ -266,7 +266,7 @@ int AWSPlatform::read_mmio(uint64_t offset, fr_t *dest) {
     rc = fpga_pci_peek(pci_bar_handle, sizeof(fr_t) * offset, dest);
 
     LOGD("[AWSPlatform] AWS fpga_pci_peek "
-        << STRHEX32 << ret << " from reg " << std::dec << offset
+        << STRHEX32 << *dest << " from reg " << std::dec << offset
         << " addr " << STRHEX64 << (sizeof(fr_t) * offset));
 
     if (rc != 0) {

--- a/runtime/src/common.h
+++ b/runtime/src/common.h
@@ -25,7 +25,7 @@ constexpr int ERROR = -1;
 typedef uint64_t fa_t;
 
 /// Fletcher Register Type
-typedef uint64_t fr_t;
+typedef uint32_t fr_t;
 
 /**
  * A Buffer configuration element


### PR DESCRIPTION
This updates the UserCore MMIO register locations and size to that used by the latest version of Fletchgen. **This currently breaks the build for the SNAP platform.**
It also changes the header install location back from `.../include/src` to `.../include/fletcher`.

- MMIO register size changed from 64 bit to 32 bit
- Control and status register are interchanged
- Control bits are re-assigned
- Buffer address registers moved
- FPGA return type is now fa_t (Fletcher address, 64 bit) instead of fr_t (Fletcher register, was 64 bit, now 32 bit)