### PR TITLE
Fletchgen connect first/last idx, misc fixes

### DIFF
--- a/codegen/fletchgen/src/column-wrapper.cc
+++ b/codegen/fletchgen/src/column-wrapper.cc
@@ -724,6 +724,14 @@ void ColumnWrapper::implementUserRegs() {
     architecture()->addConnection(make_shared<Connection>(sroute, Range(), regs_out_en(), wer));
   }
 
+  /* First and last index regs */
+  auto p_idx_first = usercore_->entity()->getPortByName(nameFrom({"idx", "first"}));
+  auto p_idx_last  = usercore_->entity()->getPortByName(nameFrom({"idx", "last"}));
+  Range range_idx_first(Value(5) * Value(ce::REG_WIDTH) - Value(1), Value(4) * Value(ce::REG_WIDTH));
+  Range range_idx_last( Value(6) * Value(ce::REG_WIDTH) - Value(1), Value(5) * Value(ce::REG_WIDTH));
+  usercore_inst_->mapPort(p_idx_first, regs_in(), range_idx_first);
+  usercore_inst_->mapPort(p_idx_last, regs_in(), range_idx_last);
+
   /* Return regs */
   auto reg0 = usercore_->entity()->getPortByName(nameFrom({"reg", "return0"}));
   auto reg1 = usercore_->entity()->getPortByName(nameFrom({"reg", "return1"}));

--- a/codegen/fletchgen/src/column-wrapper.cc
+++ b/codegen/fletchgen/src/column-wrapper.cc
@@ -127,7 +127,7 @@ void ColumnWrapper::addReadArbiter() {
     }
 
   } else {
-    // No readers, tie off write channel
+    // No readers, tie off read channel
     architecture()->addStatement(make_shared<vhdl::Statement>("  mst_rreq_valid", "<=", "'0';"));
     architecture()->addStatement(make_shared<vhdl::Statement>("  mst_rdat_ready", "<=", "'0';"));
   }

--- a/codegen/fletchgen/src/column-wrapper.cc
+++ b/codegen/fletchgen/src/column-wrapper.cc
@@ -125,7 +125,13 @@ void ColumnWrapper::addReadArbiter() {
     for (const auto &p : rarb->mst_rdat()->ports()) {
       rarb_inst->mapPort(p.get(), p.get());
     }
+
+  } else {
+    // No readers, tie off write channel
+    architecture()->addStatement(make_shared<vhdl::Statement>("  mst_rreq_valid", "<=", "'0';"));
+    architecture()->addStatement(make_shared<vhdl::Statement>("  mst_rdat_ready", "<=", "'0';"));
   }
+
   rarb->mst_rreq()->setGroup(pgroup_++);
   rarb->mst_rdat()->setGroup(pgroup_++);
   appendStream(rarb->mst_rreq());
@@ -154,7 +160,13 @@ void ColumnWrapper::addWriteArbiter() {
     for (const auto &p : warb->mst_wdat()->ports()) {
       warb_inst->mapPort(p.get(), p.get());
     }
+
+  } else {
+    // No writers, tie off write channel
+    architecture()->addStatement(make_shared<vhdl::Statement>("  mst_wdat_valid", "<=", "'0';"));
+    architecture()->addStatement(make_shared<vhdl::Statement>("  mst_wreq_valid", "<=", "'0';"));
   }
+
   warb->mst_wreq()->setGroup(pgroup_++);
   warb->mst_wdat()->setGroup(pgroup_++);
   appendStream(warb->mst_wreq());

--- a/codegen/fletchgen/src/constants.h
+++ b/codegen/fletchgen/src/constants.h
@@ -22,8 +22,8 @@ namespace fletchgen {
  */
 namespace ce {
 
-// Status, Control, Return(2)
-constexpr unsigned int NUM_DEFAULT_REGS = 4;
+// Status, Control, Return(2), First idx, Last idx
+constexpr unsigned int NUM_DEFAULT_REGS = 6;
 
 constexpr char
     COPYRIGHT_NOTICE[] = "-- Copyright 2018 Delft University of Technology\n"

--- a/codegen/fletchgen/src/fletcher-ports.cc
+++ b/codegen/fletchgen/src/fletcher-ports.cc
@@ -52,6 +52,7 @@ string typeToString(GP type) {
     case GP::REG_USER:return "reg_user";
     case GP::SIG:return "signal";
     case GP::REG_RETURN:return "reg_return";
+    case GP::REG_IDX:return "reg_idx";
   }
   throw std::runtime_error("Unknown port type.");
 }

--- a/codegen/fletchgen/src/fletcher-ports.h
+++ b/codegen/fletchgen/src/fletcher-ports.h
@@ -88,6 +88,7 @@ enum class GP {
   REG_ADDR,    ///< Address regiser
   REG_USER,    ///< User registers
   REG_RETURN,  ///< Return register
+  REG_IDX,     ///< Row index register
   SIG,         ///< Other signals
 };
 

--- a/codegen/fletchgen/src/usercore.cc
+++ b/codegen/fletchgen/src/usercore.cc
@@ -65,11 +65,18 @@ UserCore::UserCore(std::string name, ColumnWrapper *parent, int num_addr_regs, i
              t(1) + "-- This component should be implemented by the user.\n"
   );
 
+  /* First and last index registers */
+  auto p_idx_first = make_shared<GeneralPort>(nameFrom({"idx","first"}), GP::REG_IDX, Dir::IN, Value(ce::REG_WIDTH));
+  auto p_idx_last  = make_shared<GeneralPort>(nameFrom({"idx","last"}), GP::REG_IDX, Dir::IN, Value(ce::REG_WIDTH));
+  entity()->addPort(p_idx_first, group);
+  entity()->addPort(p_idx_last , group);
+
   /* Return registers */
   auto r0 = make_shared<GeneralPort>(nameFrom({"reg","return0"}), GP::REG_RETURN, Dir::OUT, Value(ce::REG_WIDTH));
   auto r1 = make_shared<GeneralPort>(nameFrom({"reg","return1"}), GP::REG_RETURN, Dir::OUT, Value(ce::REG_WIDTH));
   entity()->addPort(r0, group);
   entity()->addPort(r1, group);
+  group++;
 
   /* Buffer Address registers */
   // Get all buffers

--- a/hardware/vhdl/axi/axi_top.vhdt
+++ b/hardware/vhdl/axi/axi_top.vhdt
@@ -124,6 +124,7 @@ architecture Behavorial of axi_top is
     generic(
       BUS_DATA_WIDTH            : natural;
       BUS_ADDR_WIDTH            : natural;
+      BUS_STROBE_WIDTH          : natural;
       BUS_LEN_WIDTH             : natural;
       BUS_BURST_STEP_LEN        : natural;
       BUS_BURST_MAX_LEN         : natural;
@@ -151,11 +152,11 @@ architecture Behavorial of axi_top is
       mst_wreq_ready            : in std_logic;
       mst_wreq_addr             : out std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
       mst_wreq_len              : out std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-      mst_wdat_valid            : in std_logic;
-      mst_wdat_ready            : out std_logic;
-      mst_wdat_data             : in std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-      mst_wdat_strobe           : in std_logic_vector(BUS_STROBE_WIDTH-1 downto 0);
-      mst_wdat_last             : in std_logic;
+      mst_wdat_valid            : out std_logic;
+      mst_wdat_ready            : in std_logic;
+      mst_wdat_data             : out std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+      mst_wdat_strobe           : out std_logic_vector(BUS_STROBE_WIDTH-1 downto 0);
+      mst_wdat_last             : out std_logic;
       regs_in                   : in std_logic_vector(NUM_REGS*REG_WIDTH-1 downto 0);
       regs_out                  : out std_logic_vector(NUM_REGS*REG_WIDTH-1 downto 0);
       regs_out_en               : out std_logic_vector(NUM_REGS-1 downto 0)
@@ -170,10 +171,22 @@ architecture Behavorial of axi_top is
   signal bus_rreq_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
   signal bus_rreq_valid         : std_logic;
   signal bus_rreq_ready         : std_logic;
+
   signal bus_rdat_data          : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
   signal bus_rdat_last          : std_logic;
   signal bus_rdat_valid         : std_logic;
   signal bus_rdat_ready         : std_logic;
+
+  signal bus_wreq_valid         : std_logic;
+  signal bus_wreq_ready         : std_logic;
+  signal bus_wreq_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal bus_wreq_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+
+  signal bus_wdat_valid         : std_logic;
+  signal bus_wdat_ready         : std_logic;
+  signal bus_wdat_data          : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal bus_wdat_strobe        : std_logic_vector(BUS_STROBE_WIDTH-1 downto 0);
+  signal bus_wdat_last          : std_logic;
 
   -- MMIO registers
   signal regs_in                : std_logic_vector(NUM_REGS*REG_WIDTH-1 downto 0);
@@ -191,6 +204,7 @@ begin
     generic map (
       BUS_DATA_WIDTH            => BUS_DATA_WIDTH,
       BUS_ADDR_WIDTH            => BUS_ADDR_WIDTH,
+      BUS_STROBE_WIDTH          => BUS_STROBE_WIDTH,
       BUS_LEN_WIDTH             => BUS_LEN_WIDTH,
       BUS_BURST_STEP_LEN        => BUS_BURST_STEP_LEN,
       BUS_BURST_MAX_LEN         => BUS_BURST_MAX_LEN,
@@ -221,6 +235,7 @@ begin
       mst_wdat_valid            => bus_wdat_valid,
       mst_wdat_ready            => bus_wdat_ready,
       mst_wdat_data             => bus_wdat_data,
+      mst_wdat_strobe           => bus_wdat_strobe,
       mst_wdat_last             => bus_wdat_last,
       regs_in                   => regs_in,
       regs_out                  => regs_out,


### PR DESCRIPTION
- Add missing signal declarations in axi_top template
- Fix in/out swap for write channel
- Add missing strobe signal and generic
- Tie off read and write channel when not used
- Connect the first/last idx registers to the user accelerator function

Closes #46 