### PR TITLE
Setup CI with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+sudo: required
+
+language: minimal
+
+services:
+  - docker
+
+env:
+  global:
+    - ARROW_VERSION=0.10.0
+
+cache:
+  directories:
+    - $HOME/docker
+
+before_install:
+  - mkdir -p $HOME/docker && ls $HOME/docker/*.tar.gz | xargs -r -I {file} sh -c "zcat {file} | docker load" || true
+
+jobs:
+  include:
+
+    - &docker-build
+      stage: build
+      name: fletchgen
+      before_script:
+        - export IMG=fletchgen SRC_PATH=codegen/fletchgen
+      script:
+        - cd $SRC_PATH && docker build -t $IMG:latest --cache-from $IMG:latest --build-arg ARROW_VERSION=$ARROW_VERSION .
+      before_cache:
+        - docker save $IMG:latest | gzip -2 > $HOME/docker/$IMG.tar.gz
+
+    - <<: *docker-build
+      name: runtime
+      before_script:
+        - export IMG=runtime SRC_PATH=runtime
+
+    - &vhdl
+      name: vhdl-93c
+      env: STD=93c
+      script:
+        # this imports all entities in vhdl/ and runs analysis and elaboration
+        - docker run --rm -e STD -v `pwd`/hardware/vhdl:/src ghdl/ghdl:ubuntu18-llvm-5.0 bash -c "shopt -s globstar && ghdl -i -v --std=$STD /src/**/*.vhd | grep entity | sed -e 's/entity //' | sed -e 's/ \*\*//' | xargs -L 1 ghdl -m --std=$STD --ieee=synopsys"
+
+    - <<: *vhdl
+      name: vhdl-08
+      env: STD=08
+
+    - stage: test
+      name: stringread
+      script:
+        - docker run --rm -it -v `pwd`/hardware/test/fletchgen/stringread:/src -v `pwd`/hardware:/hardware -e "FLETCHER_HARDWARE_DIR=/hardware" fletchgen -i src/test.fbs -o src/test_wrapper.vhd -n test -w test_wrapper -s src/test.fbs -d src/test.rb --sim src/sim_top.vhd -x src/test.srec
+        # replace the srec path
+        - sed -i -e 's/"src\/test.srec"/"src\/test\/fletchgen\/stringread\/test.srec"/' hardware/test/fletchgen/stringread/sim_top.vhd
+        - docker run --rm -v `pwd`/hardware:/src ghdl/ghdl:ubuntu18-llvm-5.0 bash -c "shopt -s globstar && ghdl -i /src/**/*.vhd && ghdl -m --ieee=synopsys sim_top && ghdl -r -v --ieee=synopsys sim_top --stop-time=1ms"

--- a/codegen/fletchgen/CMakeLists.txt
+++ b/codegen/fletchgen/CMakeLists.txt
@@ -16,6 +16,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -DDEBUG")
 # Release flags
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast")
 
+# Set runtime path
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 set(SOURCE_FILES
         src/logging.h
         src/meta.h

--- a/codegen/fletchgen/Dockerfile
+++ b/codegen/fletchgen/Dockerfile
@@ -1,0 +1,25 @@
+ARG ARROW_VERSION=0.10.0
+FROM mbrobbel/libarrow:$ARROW_VERSION
+
+LABEL fletcher=
+
+ENV BUILD_PACKAGES make cmake g++ clang
+ENV RUNTIME_PACKAGES boost-dev
+ENV CXX clang++
+
+WORKDIR fletchgen
+ADD src src
+ADD CMakeLists.txt .
+
+WORKDIR build
+RUN apk add --no-cache $BUILD_PACKAGES $RUNTIME_PACKAGES && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DENABLE_TESTS=OFF \
+      .. && \
+    make && make install && \
+    cd ../.. && rm -rf fletchgen && \
+    apk del $BUILD_PACKAGES
+
+WORKDIR /
+ENTRYPOINT ["fletchgen"]

--- a/hardware/test/fletcher.tcl
+++ b/hardware/test/fletcher.tcl
@@ -97,6 +97,8 @@ proc add_interconnect_tb {{source_dir ""}} {
   add_source $source_dir/interconnect/BusWriteSlaveMock.vhd
   add_source $source_dir/interconnect/BusWriteMasterMock.vhd
   
+  add_source $source_dir/interconnect/BusReadArbiter_tb.vhd
+  
 }
 
 proc add_buffers {{source_dir ""}} {

--- a/hardware/test/streams/streams.tcl
+++ b/hardware/test/streams/streams.tcl
@@ -23,4 +23,4 @@ add_fletcher
 add_fletcher_tb
 
 echo "Use simtest <unit name> to simulate any stream component with a testbench."
-echo "Example: simtest StreamMaximizer
+echo "Example: simtest StreamMaximizer"

--- a/hardware/vhdl/columns/ColumnWriterLevel.vhd
+++ b/hardware/vhdl/columns/ColumnWriterLevel.vhd
@@ -180,7 +180,9 @@ begin
         cmdIn_firstIdx          => cmd_firstIdx,
         cmdIn_lastIdx           => cmd_lastIdx,
         cmdIn_baseAddr          => cmd_ctrl,
+        cmdIn_ctrl              => "0",
         cmdIn_tag               => cmd_tag,
+        cmdIn_implicit          => '0',
 
         unlock_valid            => unlock_valid,
         unlock_ready            => unlock_ready,

--- a/hardware/vhdl/columns/ColumnWriterListPrim.vhd
+++ b/hardware/vhdl/columns/ColumnWriterListPrim.vhd
@@ -302,6 +302,7 @@ begin
       cmdIn_baseAddr            => cmd_ctrl(CSI(2)-1 downto CSI(1)),
       cmdIn_ctrl                => cmd_ctrl(CSI(1)-1 downto CSI(0)),
       cmdIn_tag                 => cmd_tag,
+      cmdIn_implicit            => '0',
 
       cmdOut_valid              => b_cmd_valid,
       cmdOut_ready              => b_cmd_ready,

--- a/hardware/vhdl/columns/ColumnWriterListPrim.vhd
+++ b/hardware/vhdl/columns/ColumnWriterListPrim.vhd
@@ -364,6 +364,7 @@ begin
       cmdIn_baseAddr            => b_cmd_baseAddr,
       cmdIn_ctrl                => "0",
       cmdIn_tag                 => b_cmd_tag,
+      cmdIn_implicit            => '0',
 
       unlock_valid              => b_unlock_valid,
       unlock_ready              => b_unlock_ready,

--- a/hardware/vhdl/interconnect/BusReadArbiter_tb.vhd
+++ b/hardware/vhdl/interconnect/BusReadArbiter_tb.vhd
@@ -34,91 +34,91 @@ architecture Behavioral of BusReadArbiter_tb is
   signal reset                  : std_logic;
 
   -- Master A to arbiter.
-  signal ma2b_req_valid         : std_logic;
-  signal ma2b_req_ready         : std_logic;
-  signal ma2b_req_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
-  signal ma2b_req_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-  signal ma2b_resp_valid        : std_logic;
-  signal ma2b_resp_ready        : std_logic;
-  signal ma2b_resp_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal ma2b_resp_last         : std_logic;
+  signal ma2b_rreq_valid        : std_logic;
+  signal ma2b_rreq_ready        : std_logic;
+  signal ma2b_rreq_addr         : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal ma2b_rreq_len          : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+  signal ma2b_rdat_valid        : std_logic;
+  signal ma2b_rdat_ready        : std_logic;
+  signal ma2b_rdat_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal ma2b_rdat_last         : std_logic;
 
-  signal ma2b_resp_data_m       : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal ma2b_resp_last_m       : std_logic;
+  signal ma2b_rdat_data_m       : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal ma2b_rdat_last_m       : std_logic;
 
-  signal ba2a_req_valid         : std_logic;
-  signal ba2a_req_ready         : std_logic;
-  signal ba2a_req_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
-  signal ba2a_req_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-  signal ba2a_resp_valid        : std_logic;
-  signal ba2a_resp_ready        : std_logic;
-  signal ba2a_resp_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal ba2a_resp_last         : std_logic;
+  signal ba2a_rreq_valid        : std_logic;
+  signal ba2a_rreq_ready        : std_logic;
+  signal ba2a_rreq_addr         : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal ba2a_rreq_len          : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+  signal ba2a_rdat_valid        : std_logic;
+  signal ba2a_rdat_ready        : std_logic;
+  signal ba2a_rdat_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal ba2a_rdat_last         : std_logic;
 
   -- Master B to arbiter.
-  signal mb2b_req_valid         : std_logic;
-  signal mb2b_req_ready         : std_logic;
-  signal mb2b_req_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
-  signal mb2b_req_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-  signal mb2b_resp_valid        : std_logic;
-  signal mb2b_resp_ready        : std_logic;
-  signal mb2b_resp_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal mb2b_resp_last         : std_logic;
+  signal mb2b_rreq_valid        : std_logic;
+  signal mb2b_rreq_ready        : std_logic;
+  signal mb2b_rreq_addr         : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal mb2b_rreq_len          : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+  signal mb2b_rdat_valid        : std_logic;
+  signal mb2b_rdat_ready        : std_logic;
+  signal mb2b_rdat_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal mb2b_rdat_last         : std_logic;
 
-  signal mb2b_resp_data_m       : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal mb2b_resp_last_m       : std_logic;
+  signal mb2b_rdat_data_m       : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal mb2b_rdat_last_m       : std_logic;
 
-  signal bb2a_req_valid         : std_logic;
-  signal bb2a_req_ready         : std_logic;
-  signal bb2a_req_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
-  signal bb2a_req_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-  signal bb2a_resp_valid        : std_logic;
-  signal bb2a_resp_ready        : std_logic;
-  signal bb2a_resp_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal bb2a_resp_last         : std_logic;
+  signal bb2a_rreq_valid        : std_logic;
+  signal bb2a_rreq_ready        : std_logic;
+  signal bb2a_rreq_addr         : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal bb2a_rreq_len          : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+  signal bb2a_rdat_valid        : std_logic;
+  signal bb2a_rdat_ready        : std_logic;
+  signal bb2a_rdat_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal bb2a_rdat_last         : std_logic;
 
   -- Master C to arbiter.
-  signal mc2b_req_valid         : std_logic;
-  signal mc2b_req_ready         : std_logic;
-  signal mc2b_req_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
-  signal mc2b_req_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-  signal mc2b_resp_valid        : std_logic;
-  signal mc2b_resp_ready        : std_logic;
-  signal mc2b_resp_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal mc2b_resp_last         : std_logic;
+  signal mc2b_rreq_valid        : std_logic;
+  signal mc2b_rreq_ready        : std_logic;
+  signal mc2b_rreq_addr         : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal mc2b_rreq_len          : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+  signal mc2b_rdat_valid        : std_logic;
+  signal mc2b_rdat_ready        : std_logic;
+  signal mc2b_rdat_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal mc2b_rdat_last         : std_logic;
 
-  signal mc2b_resp_data_m       : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal mc2b_resp_last_m       : std_logic;
+  signal mc2b_rdat_data_m       : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal mc2b_rdat_last_m       : std_logic;
 
-  signal bc2a_req_valid         : std_logic;
-  signal bc2a_req_ready         : std_logic;
-  signal bc2a_req_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
-  signal bc2a_req_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-  signal bc2a_resp_valid        : std_logic;
-  signal bc2a_resp_ready        : std_logic;
-  signal bc2a_resp_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal bc2a_resp_last         : std_logic;
+  signal bc2a_rreq_valid        : std_logic;
+  signal bc2a_rreq_ready        : std_logic;
+  signal bc2a_rreq_addr         : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal bc2a_rreq_len          : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+  signal bc2a_rdat_valid        : std_logic;
+  signal bc2a_rdat_ready        : std_logic;
+  signal bc2a_rdat_data         : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal bc2a_rdat_last         : std_logic;
 
   -- Arbiter to slave.
-  signal a2s_req_valid          : std_logic;
-  signal a2s_req_ready          : std_logic;
-  signal a2s_req_addr           : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
-  signal a2s_req_len            : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
-  signal a2s_resp_valid         : std_logic;
-  signal a2s_resp_ready         : std_logic;
-  signal a2s_resp_data          : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
-  signal a2s_resp_last          : std_logic;
+  signal a2s_rreq_valid         : std_logic;
+  signal a2s_rreq_ready         : std_logic;
+  signal a2s_rreq_addr          : std_logic_vector(BUS_ADDR_WIDTH-1 downto 0);
+  signal a2s_rreq_len           : std_logic_vector(BUS_LEN_WIDTH-1 downto 0);
+  signal a2s_rdat_valid         : std_logic;
+  signal a2s_rdat_ready         : std_logic;
+  signal a2s_rdat_data          : std_logic_vector(BUS_DATA_WIDTH-1 downto 0);
+  signal a2s_rdat_last          : std_logic;
 
 begin
 
-  ma2b_resp_data_m <= ma2b_resp_data when ma2b_resp_valid = '1' and ma2b_resp_ready = '1' else (others => 'Z');
-  ma2b_resp_last_m <= ma2b_resp_last when ma2b_resp_valid = '1' and ma2b_resp_ready = '1' else 'Z';
+  ma2b_rdat_data_m <= ma2b_rdat_data when ma2b_rdat_valid = '1' and ma2b_rdat_ready = '1' else (others => 'Z');
+  ma2b_rdat_last_m <= ma2b_rdat_last when ma2b_rdat_valid = '1' and ma2b_rdat_ready = '1' else 'Z';
 
-  mb2b_resp_data_m <= mb2b_resp_data when mb2b_resp_valid = '1' and mb2b_resp_ready = '1' else (others => 'Z');
-  mb2b_resp_last_m <= mb2b_resp_last when mb2b_resp_valid = '1' and mb2b_resp_ready = '1' else 'Z';
+  mb2b_rdat_data_m <= mb2b_rdat_data when mb2b_rdat_valid = '1' and mb2b_rdat_ready = '1' else (others => 'Z');
+  mb2b_rdat_last_m <= mb2b_rdat_last when mb2b_rdat_valid = '1' and mb2b_rdat_ready = '1' else 'Z';
 
-  mc2b_resp_data_m <= mc2b_resp_data when mc2b_resp_valid = '1' and mc2b_resp_ready = '1' else (others => 'Z');
-  mc2b_resp_last_m <= mc2b_resp_last when mc2b_resp_valid = '1' and mc2b_resp_ready = '1' else 'Z';
+  mc2b_rdat_data_m <= mc2b_rdat_data when mc2b_rdat_valid = '1' and mc2b_rdat_ready = '1' else (others => 'Z');
+  mc2b_rdat_last_m <= mc2b_rdat_last when mc2b_rdat_valid = '1' and mc2b_rdat_ready = '1' else 'Z';
 
   clk_proc: process is
   begin
@@ -148,14 +148,14 @@ begin
     port map (
       clk                       => clk,
       reset                     => reset,
-      req_valid                 => ma2b_req_valid,
-      req_ready                 => ma2b_req_ready,
-      req_addr                  => ma2b_req_addr,
-      req_len                   => ma2b_req_len,
-      resp_valid                => ma2b_resp_valid,
-      resp_ready                => ma2b_resp_ready,
-      resp_data                 => ma2b_resp_data,
-      resp_last                 => ma2b_resp_last
+      rreq_valid                => ma2b_rreq_valid,
+      rreq_ready                => ma2b_rreq_ready,
+      rreq_addr                 => ma2b_rreq_addr,
+      rreq_len                  => ma2b_rreq_len,
+      rdat_valid                => ma2b_rdat_valid,
+      rdat_ready                => ma2b_rdat_ready,
+      rdat_data                 => ma2b_rdat_data,
+      rdat_last                 => ma2b_rdat_last
     );
 
   mst_a_buffer_inst: BusReadBuffer
@@ -165,32 +165,32 @@ begin
       BUS_DATA_WIDTH            => BUS_DATA_WIDTH,
       FIFO_DEPTH                => 16,
       RAM_CONFIG                => "",
-      REQ_IN_SLICE              => false,
-      REQ_OUT_SLICE             => true,
-      RESP_IN_SLICE             => false,
-      RESP_OUT_SLICE            => true
+      SLV_REQ_SLICE             => false,
+      MST_REQ_SLICE             => false,
+      MST_DAT_SLICE             => false,
+      SLV_DAT_SLICE             => false
     )
     port map (
       clk                       => clk,
       reset                     => reset,
 
-      mst_req_valid             => ma2b_req_valid,
-      mst_req_ready             => ma2b_req_ready,
-      mst_req_addr              => ma2b_req_addr,
-      mst_req_len               => ma2b_req_len,
-      mst_resp_valid            => ma2b_resp_valid,
-      mst_resp_ready            => ma2b_resp_ready,
-      mst_resp_data             => ma2b_resp_data,
-      mst_resp_last             => ma2b_resp_last,
+      mst_rreq_valid            => ma2b_rreq_valid,
+      mst_rreq_ready            => ma2b_rreq_ready,
+      mst_rreq_addr             => ma2b_rreq_addr,
+      mst_rreq_len              => ma2b_rreq_len,
+      mst_rdat_valid            => ma2b_rdat_valid,
+      mst_rdat_ready            => ma2b_rdat_ready,
+      mst_rdat_data             => ma2b_rdat_data,
+      mst_rdat_last             => ma2b_rdat_last,
 
-      slv_req_valid             => ba2a_req_valid,
-      slv_req_ready             => ba2a_req_ready,
-      slv_req_addr              => ba2a_req_addr,
-      slv_req_len               => ba2a_req_len,
-      slv_resp_valid            => ba2a_resp_valid,
-      slv_resp_ready            => ba2a_resp_ready,
-      slv_resp_data             => ba2a_resp_data,
-      slv_resp_last             => ba2a_resp_last
+      slv_rreq_valid            => ba2a_rreq_valid,
+      slv_rreq_ready            => ba2a_rreq_ready,
+      slv_rreq_addr             => ba2a_rreq_addr,
+      slv_rreq_len              => ba2a_rreq_len,
+      slv_rdat_valid            => ba2a_rdat_valid,
+      slv_rdat_ready            => ba2a_rdat_ready,
+      slv_rdat_data             => ba2a_rdat_data,
+      slv_rdat_last             => ba2a_rdat_last
     );
 
   mst_b_inst: BusReadMasterMock
@@ -203,14 +203,14 @@ begin
     port map (
       clk                       => clk,
       reset                     => reset,
-      req_valid                 => mb2b_req_valid,
-      req_ready                 => mb2b_req_ready,
-      req_addr                  => mb2b_req_addr,
-      req_len                   => mb2b_req_len,
-      resp_valid                => mb2b_resp_valid,
-      resp_ready                => mb2b_resp_ready,
-      resp_data                 => mb2b_resp_data,
-      resp_last                 => mb2b_resp_last
+      rreq_valid                => mb2b_rreq_valid,
+      rreq_ready                => mb2b_rreq_ready,
+      rreq_addr                 => mb2b_rreq_addr,
+      rreq_len                  => mb2b_rreq_len,
+      rdat_valid                => mb2b_rdat_valid,
+      rdat_ready                => mb2b_rdat_ready,
+      rdat_data                 => mb2b_rdat_data,
+      rdat_last                 => mb2b_rdat_last
     );
 
   mst_b_buffer_inst: BusReadBuffer
@@ -220,32 +220,32 @@ begin
       BUS_DATA_WIDTH            => BUS_DATA_WIDTH,
       FIFO_DEPTH                => 16,
       RAM_CONFIG                => "",
-      REQ_IN_SLICE              => false,
-      REQ_OUT_SLICE             => true,
-      RESP_IN_SLICE             => false,
-      RESP_OUT_SLICE            => true
+      SLV_REQ_SLICE             => false,
+      MST_REQ_SLICE             => false,
+      MST_DAT_SLICE             => false,
+      SLV_DAT_SLICE             => false
     )
     port map (
       clk                       => clk,
       reset                     => reset,
 
-      slv_rreq_valid             => mb2b_req_valid,
-      slv_rreq_ready             => mb2b_req_ready,
-      slv_rreq_addr              => mb2b_req_addr,
-      slv_rreq_len               => mb2b_req_len,
-      slv_rdat_valid            => mb2b_resp_valid,
-      slv_rdat_ready            => mb2b_resp_ready,
-      slv_rdat_data             => mb2b_resp_data,
-      slv_rdat_last             => mb2b_resp_last,
+      slv_rreq_valid            => mb2b_rreq_valid,
+      slv_rreq_ready            => mb2b_rreq_ready,
+      slv_rreq_addr             => mb2b_rreq_addr,
+      slv_rreq_len              => mb2b_rreq_len,
+      slv_rdat_valid            => mb2b_rdat_valid,
+      slv_rdat_ready            => mb2b_rdat_ready,
+      slv_rdat_data             => mb2b_rdat_data,
+      slv_rdat_last             => mb2b_rdat_last,
 
-      mst_rreq_valid             => bb2a_req_valid,
-      mst_rreq_ready             => bb2a_req_ready,
-      mst_rreq_addr              => bb2a_req_addr,
-      mst_rreq_len               => bb2a_req_len,
-      mst_rdat_valid            => bb2a_resp_valid,
-      mst_rdat_ready            => bb2a_resp_ready,
-      mst_rdat_data             => bb2a_resp_data,
-      mst_rdat_last             => bb2a_resp_last
+      mst_rreq_valid            => bb2a_rreq_valid,
+      mst_rreq_ready            => bb2a_rreq_ready,
+      mst_rreq_addr             => bb2a_rreq_addr,
+      mst_rreq_len              => bb2a_rreq_len,
+      mst_rdat_valid            => bb2a_rdat_valid,
+      mst_rdat_ready            => bb2a_rdat_ready,
+      mst_rdat_data             => bb2a_rdat_data,
+      mst_rdat_last             => bb2a_rdat_last
     );
 
   mst_c_inst: BusReadMasterMock
@@ -258,14 +258,14 @@ begin
     port map (
       clk                       => clk,
       reset                     => reset,
-      req_valid                 => mc2b_req_valid,
-      req_ready                 => mc2b_req_ready,
-      req_addr                  => mc2b_req_addr,
-      req_len                   => mc2b_req_len,
-      resp_valid                => mc2b_resp_valid,
-      resp_ready                => mc2b_resp_ready,
-      resp_data                 => mc2b_resp_data,
-      resp_last                 => mc2b_resp_last
+      rreq_valid                => mc2b_rreq_valid,
+      rreq_ready                => mc2b_rreq_ready,
+      rreq_addr                 => mc2b_rreq_addr,
+      rreq_len                  => mc2b_rreq_len,
+      rdat_valid                => mc2b_rdat_valid,
+      rdat_ready                => mc2b_rdat_ready,
+      rdat_data                 => mc2b_rdat_data,
+      rdat_last                 => mc2b_rdat_last
     );
 
   mst_c_buffer_inst: BusReadBuffer
@@ -275,32 +275,32 @@ begin
       BUS_DATA_WIDTH            => BUS_DATA_WIDTH,
       FIFO_DEPTH                => 16,
       RAM_CONFIG                => "",
-      REQ_IN_SLICE              => false,
-      REQ_OUT_SLICE             => true,
-      RESP_IN_SLICE             => false,
-      RESP_OUT_SLICE            => true
+      SLV_REQ_SLICE             => false,
+      MST_REQ_SLICE             => false,
+      MST_DAT_SLICE             => false,
+      SLV_DAT_SLICE             => false
     )
     port map (
       clk                       => clk,
       reset                     => reset,
 
-      mst_req_valid             => mc2b_req_valid,
-      mst_req_ready             => mc2b_req_ready,
-      mst_req_addr              => mc2b_req_addr,
-      mst_req_len               => mc2b_req_len,
-      mst_resp_valid            => mc2b_resp_valid,
-      mst_resp_ready            => mc2b_resp_ready,
-      mst_resp_data             => mc2b_resp_data,
-      mst_resp_last             => mc2b_resp_last,
+      mst_rreq_valid            => mc2b_rreq_valid,
+      mst_rreq_ready            => mc2b_rreq_ready,
+      mst_rreq_addr             => mc2b_rreq_addr,
+      mst_rreq_len              => mc2b_rreq_len,
+      mst_rdat_valid            => mc2b_rdat_valid,
+      mst_rdat_ready            => mc2b_rdat_ready,
+      mst_rdat_data             => mc2b_rdat_data,
+      mst_rdat_last             => mc2b_rdat_last,
 
-      slv_req_valid             => bc2a_req_valid,
-      slv_req_ready             => bc2a_req_ready,
-      slv_req_addr              => bc2a_req_addr,
-      slv_req_len               => bc2a_req_len,
-      slv_resp_valid            => bc2a_resp_valid,
-      slv_resp_ready            => bc2a_resp_ready,
-      slv_resp_data             => bc2a_resp_data,
-      slv_resp_last             => bc2a_resp_last
+      slv_rreq_valid            => bc2a_rreq_valid,
+      slv_rreq_ready            => bc2a_rreq_ready,
+      slv_rreq_addr             => bc2a_rreq_addr,
+      slv_rreq_len              => bc2a_rreq_len,
+      slv_rdat_valid            => bc2a_rdat_valid,
+      slv_rdat_ready            => bc2a_rdat_ready,
+      slv_rdat_data             => bc2a_rdat_data,
+      slv_rdat_last             => bc2a_rdat_last
     );
 
   uut: BusReadArbiter
@@ -312,50 +312,50 @@ begin
       ARB_METHOD                => "ROUND-ROBIN",
       MAX_OUTSTANDING           => 4,
       RAM_CONFIG                => "",
-      REQ_IN_SLICES             => true,
-      REQ_OUT_SLICE             => true,
-      RESP_IN_SLICE             => true,
-      RESP_OUT_SLICES           => true
+      SLV_REQ_SLICES            => false,
+      MST_REQ_SLICE             => false,
+      MST_DAT_SLICE             => false,
+      SLV_DAT_SLICES            => false
     )
     port map (
-      clk                       => clk,
-      reset                     => reset,
+      bus_clk                   => clk,
+      bus_reset                 => reset,
 
-      slv_req_valid             => a2s_req_valid,
-      slv_req_ready             => a2s_req_ready,
-      slv_req_addr              => a2s_req_addr,
-      slv_req_len               => a2s_req_len,
-      slv_resp_valid            => a2s_resp_valid,
-      slv_resp_ready            => a2s_resp_ready,
-      slv_resp_data             => a2s_resp_data,
-      slv_resp_last             => a2s_resp_last,
+      mst_rreq_valid            => a2s_rreq_valid,
+      mst_rreq_ready            => a2s_rreq_ready,
+      mst_rreq_addr             => a2s_rreq_addr,
+      mst_rreq_len              => a2s_rreq_len,
+      mst_rdat_valid            => a2s_rdat_valid,
+      mst_rdat_ready            => a2s_rdat_ready,
+      mst_rdat_data             => a2s_rdat_data,
+      mst_rdat_last             => a2s_rdat_last,
 
-      bm0_req_valid             => ba2a_req_valid,
-      bm0_req_ready             => ba2a_req_ready,
-      bm0_req_addr              => ba2a_req_addr,
-      bm0_req_len               => ba2a_req_len,
-      bm0_resp_valid            => ba2a_resp_valid,
-      bm0_resp_ready            => ba2a_resp_ready,
-      bm0_resp_data             => ba2a_resp_data,
-      bm0_resp_last             => ba2a_resp_last,
-
-      bm1_req_valid             => bb2a_req_valid,
-      bm1_req_ready             => bb2a_req_ready,
-      bm1_req_addr              => bb2a_req_addr,
-      bm1_req_len               => bb2a_req_len,
-      bm1_resp_valid            => bb2a_resp_valid,
-      bm1_resp_ready            => bb2a_resp_ready,
-      bm1_resp_data             => bb2a_resp_data,
-      bm1_resp_last             => bb2a_resp_last,
-
-      bm2_req_valid             => bc2a_req_valid,
-      bm2_req_ready             => bc2a_req_ready,
-      bm2_req_addr              => bc2a_req_addr,
-      bm2_req_len               => bc2a_req_len,
-      bm2_resp_valid            => bc2a_resp_valid,
-      bm2_resp_ready            => bc2a_resp_ready,
-      bm2_resp_data             => bc2a_resp_data,
-      bm2_resp_last             => bc2a_resp_last
+      bs00_rreq_valid           => ba2a_rreq_valid,
+      bs00_rreq_ready           => ba2a_rreq_ready,
+      bs00_rreq_addr            => ba2a_rreq_addr,
+      bs00_rreq_len             => ba2a_rreq_len,
+      bs00_rdat_valid           => ba2a_rdat_valid,
+      bs00_rdat_ready           => ba2a_rdat_ready,
+      bs00_rdat_data            => ba2a_rdat_data,
+      bs00_rdat_last            => ba2a_rdat_last,
+                                
+      bs01_rreq_valid           => bb2a_rreq_valid,
+      bs01_rreq_ready           => bb2a_rreq_ready,
+      bs01_rreq_addr            => bb2a_rreq_addr,
+      bs01_rreq_len             => bb2a_rreq_len,
+      bs01_rdat_valid           => bb2a_rdat_valid,
+      bs01_rdat_ready           => bb2a_rdat_ready,
+      bs01_rdat_data            => bb2a_rdat_data,
+      bs01_rdat_last            => bb2a_rdat_last,
+                                
+      bs02_rreq_valid           => bc2a_rreq_valid,
+      bs02_rreq_ready           => bc2a_rreq_ready,
+      bs02_rreq_addr            => bc2a_rreq_addr,
+      bs02_rreq_len             => bc2a_rreq_len,
+      bs02_rdat_valid           => bc2a_rdat_valid,
+      bs02_rdat_ready           => bc2a_rdat_ready,
+      bs02_rdat_data            => bc2a_rdat_data,
+      bs02_rdat_last            => bc2a_rdat_last
     );
 
   slave_inst: BusReadSlaveMock
@@ -368,14 +368,14 @@ begin
     port map (
       clk                       => clk,
       reset                     => reset,
-      req_valid                 => a2s_req_valid,
-      req_ready                 => a2s_req_ready,
-      req_addr                  => a2s_req_addr,
-      req_len                   => a2s_req_len,
-      resp_valid                => a2s_resp_valid,
-      resp_ready                => a2s_resp_ready,
-      resp_data                 => a2s_resp_data,
-      resp_last                 => a2s_resp_last
+      rreq_valid                => a2s_rreq_valid,
+      rreq_ready                => a2s_rreq_ready,
+      rreq_addr                 => a2s_rreq_addr,
+      rreq_len                  => a2s_rreq_len,
+      rdat_valid                => a2s_rdat_valid,
+      rdat_ready                => a2s_rdat_ready,
+      rdat_data                 => a2s_rdat_data,
+      rdat_last                 => a2s_rdat_last
     );
 
 end Behavioral;

--- a/hardware/vhdl/interconnect/Interconnect.vhd
+++ b/hardware/vhdl/interconnect/Interconnect.vhd
@@ -587,7 +587,7 @@ package Interconnect is
   -----------------------------------------------------------------------------
   -- pragma translate_off
 
-  component BusMasterMock is
+  component BusReadMasterMock is
     generic (
       BUS_ADDR_WIDTH            : natural := 32;
       BUS_LEN_WIDTH             : natural := 8;

--- a/hardware/vhdl/streams/StreamBarrel_tb.vhd
+++ b/hardware/vhdl/streams/StreamBarrel_tb.vhd
@@ -27,16 +27,18 @@ end StreamBarrel_tb;
 architecture tb of StreamBarrel_tb is
   constant ELEMENT_WIDTH        : natural := 8;
   constant COUNT_MAX            : natural := 4;
-  constant ROTATE_WIDTH         : natural := 3;
+  constant AMOUNT_MAX           : natural := 4;
+  constant AMOUNT_WIDTH         : natural := 3;
   constant DIRECTION            : string  := "left";
   constant OPERATION            : string  := "shift";
   constant CTRL_WIDTH           : natural := 1;
+  constant STAGES               : natural := 4;
 
   signal clk                    : std_logic;
   signal reset                  : std_logic;
   signal in_valid               : std_logic;
   signal in_ready               : std_logic;
-  signal in_rotate              : std_logic_vector(ROTATE_WIDTH-1 downto 0);
+  signal in_rotate              : std_logic_vector(AMOUNT_WIDTH-1 downto 0);
   signal in_data                : std_logic_vector(COUNT_MAX*ELEMENT_WIDTH-1 downto 0);
   signal in_ctrl                : std_logic_vector(CTRL_WIDTH-1 downto 0);
   signal out_valid              : std_logic;
@@ -80,7 +82,7 @@ begin
         in_data((i+1)*ELEMENT_WIDTH-1 downto i * ELEMENT_WIDTH) <= std_logic_vector(to_unsigned(i, ELEMENT_WIDTH));
       end loop;
       
-      in_rotate <= std_logic_vector(to_unsigned(x mod COUNT_MAX, ROTATE_WIDTH));
+      in_rotate <= std_logic_vector(to_unsigned(x mod COUNT_MAX, AMOUNT_WIDTH));
       in_ctrl <= "0";
       in_valid <= '1';     
       
@@ -98,10 +100,12 @@ begin
     generic map (
       ELEMENT_WIDTH   => ELEMENT_WIDTH,
       COUNT_MAX       => COUNT_MAX,
-      ROTATE_WIDTH    => ROTATE_WIDTH,
+      AMOUNT_WIDTH    => AMOUNT_WIDTH,
+      AMOUNT_MAX      => AMOUNT_MAX,
       DIRECTION       => DIRECTION,
       OPERATION       => OPERATION,
-      CTRL_WIDTH      => CTRL_WIDTH   
+      CTRL_WIDTH      => CTRL_WIDTH,
+      STAGES          => STAGES
     )
     port map (
       clk             => clk,

--- a/hardware/vhdl/streams/StreamParallelizer_tb.vhd
+++ b/hardware/vhdl/streams/StreamParallelizer_tb.vhd
@@ -105,8 +105,10 @@ begin
     generic map (
       DATA_WIDTH                => 4,
       CTRL_WIDTH                => 1,
-      FACTOR                    => 4,
-      COUNT_WIDTH               => 2
+      IN_COUNT_WIDTH            => 1,
+      IN_COUNT_MAX              => 1,
+      OUT_COUNT_MAX             => 4,
+      OUT_COUNT_WIDTH           => 2
     )
     port map (
       clk                       => clk,

--- a/hardware/vhdl/wrapper/UserCoreMock.vhd
+++ b/hardware/vhdl/wrapper/UserCoreMock.vhd
@@ -301,7 +301,7 @@ begin
       if reset = '1' then
         expected_result         <= u(0, ELEMENT_WIDTH);
       else
-        if cmd_valid = '1' and cmd_ready = '1' then
+        if rq.valid = '1' and cmd_ready = '1' then
           -- The expected result is the sum of indices of the requested indexes
           -- If first idx = a and last idx = b then
           -- s is the sum from n=a to n=b-1 of n, which is

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,0 +1,20 @@
+ARG ARROW_VERSION=0.10.0
+FROM mbrobbel/libarrow:$ARROW_VERSION
+
+LABEL fletcher=
+
+ENV BUILD_PACKAGES make cmake g++
+ENV RUNTIME_PACKAGES boost-dev
+
+WORKDIR runtime
+ADD src src
+ADD CMakeLists.txt .
+
+WORKDIR build
+RUN apk add --no-cache $BUILD_PACKAGES $RUNTIME_PACKAGES && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      .. && \
+    make && make install && \
+    cd ../.. && rm -rf runtime && \
+    apk del $BUILD_PACKAGES

--- a/runtime/src/FPGAPlatform.cpp
+++ b/runtime/src/FPGAPlatform.cpp
@@ -84,7 +84,7 @@ std::string FPGAPlatform::name() {
 void FPGAPlatform::append_chunk_buffer_config(const std::shared_ptr<arrow::ArrayData> &array_data,
                                               const std::shared_ptr<arrow::Field> &field,
                                               std::vector<BufConfig> &config_vector,
-                                              uint depth) {
+                                              unsigned int depth) {
   LOGD(std::string(depth, '\t') << "Chunk (ArrayData):");
   LOGD(std::string(depth, '\t') << "\tType: " << array_data->type->ToString());
   LOGD(std::string(depth, '\t') << "\tBuffers: " << array_data->buffers.size());

--- a/runtime/src/FPGAPlatform.h
+++ b/runtime/src/FPGAPlatform.h
@@ -130,7 +130,7 @@ class FPGAPlatform
   void append_chunk_buffer_config(const std::shared_ptr<arrow::ArrayData>& array_data,
                                   const std::shared_ptr<arrow::Field>& field,
                                   std::vector<BufConfig>& config_vector,
-                                  uint depth = 1);
+                                  unsigned int depth = 1);
 };
 
 std::string ToString(std::shared_ptr<arrow::Buffer> buf, int width = 64);


### PR DESCRIPTION
This adds a starting point for running builds and tests for all pushed branches and/or open pull-requests of this project using Travis.

Check [here](https://travis-ci.com/mbrobbel/fletcher/builds/83920788) for an example build of my forked project (on another branch with some broken VHDL files removed).

This change adds the following:
A `.travis.yml` file in the root of the repository which defines our build environment, build stages and their jobs. Currently it is setup to builds both `fletchgen` and `runtime` using Docker with the added Dockerfiles. In order to speed up the builds I pushed [an image](https://github.com/mbrobbel/libarrow) to [Docker Hub](https://hub.docker.com/r/mbrobbel/libarrow/) with libarrow installed, to use as the base of these images.
It also has two jobs in the build stage to compile the VHDL sources using `ghdl` for VHDL-93c and VHDL-08. We'll have to make some changes to the VHDL sources to make these jobs pass.

The test stage has a single job which tests `fletchgen` and the VHDL sources using the `stringread` example. First it uses the `fletchgen` image built during the build stage to generate the wrappers and simulation files. Then it uses `ghdl` to run the simulation. We'll have to merge https://github.com/johanpel/fletcher/pull/52 and then rebase to get this to pass.

This change also includes a small change in the `runtime` in order to get it to compile (`uint` to `unsigned int`), and a small change in the `CMake` file of `fletchgen`, to add lib paths to linker search and installed rpath.

We'll have to setup Travis for this repository in order to actually run the builds.

Closes #16 