### PR TITLE
Enable branch builds for master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - master
+
 sudo: required
 
 language: minimal


### PR DESCRIPTION
With this we can enable both branch builds and pull request builds in Travis. It will only build pull requests and new commits on master.