### PR TITLE
aws: use XDMA driver for performance

### DIFF
--- a/runtime/src/aws/aws.h
+++ b/runtime/src/aws/aws.h
@@ -62,7 +62,7 @@ class AWSPlatform : public FPGAPlatform {
   int bar_id;
   pci_bar_handle_t pci_bar_handle;
   char device_filename[256];
-  int edma_fd[AWS_NUM_QUEUES];
+  int xdma_fd[AWS_NUM_QUEUES];
   uint64_t alignment = 4096;  // TODO: this should become 64 after Arrow spec.
 
   size_t copy_to_ddr(uint8_t *source, fa_t offset, size_t size);


### PR DESCRIPTION
Provides a performance improvement of about 4x, with no know side-effects. The XDMA drivers will need to be compiled and loaded instead of the EDMA drivers.

Configuring the driver to use polling mode instead of interrupt mode can improve performance slightly further:
`$ sudo modprobe xdma poll_mode=1`