### PR TITLE
Fixed axi_mmio register readability check

### DIFF
--- a/hardware/vhdl/axi/axi_mmio.tcl
+++ b/hardware/vhdl/axi/axi_mmio.tcl
@@ -1,6 +1,7 @@
 source $::env(FLETCHER_HARDWARE_DIR)/test/compile.tcl
 source $::env(FLETCHER_HARDWARE_DIR)/test/utils.tcl
 
+add_source $::env(FLETCHER_HARDWARE_DIR)/vhdl/utils/Utils.vhd
 add_source axi.vhd
 add_source axi_mmio.vhd
 add_source axi_mmio_tb.vhd

--- a/hardware/vhdl/axi/axi_mmio_tb.vhd
+++ b/hardware/vhdl/axi/axi_mmio_tb.vhd
@@ -123,7 +123,7 @@ begin
 
       loop
         -- Set address and validate
-        s_axi_araddr <= std_logic_vector(to_unsigned(raddr, BUS_ADDR_WIDTH));
+        s_axi_araddr <= std_logic_vector(to_unsigned(raddr * 4, BUS_ADDR_WIDTH));
         s_axi_arvalid <= '1';
         
         -- Wait for handshake
@@ -182,7 +182,7 @@ begin
     wait until bus_write_start;
 
     loop
-      s_axi_awaddr <= std_logic_vector(to_unsigned(waddr, BUS_ADDR_WIDTH));
+      s_axi_awaddr <= std_logic_vector(to_unsigned(waddr * 4, BUS_ADDR_WIDTH));
       s_axi_awvalid <= '1';
       s_axi_bready <= '0';
 


### PR DESCRIPTION
The register readability check depended on the address of the previous write, not the current read (base line 261). The register number reported in simulation when writing a read-only register was wrong in the same way (base line 233). In general I don't see any reason to keep separate states for the read and write address since the unit can only do one request at a time, so I just combined them to fix the issue.