### PR TITLE
Disable tests in fletchgen build Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DFLETCHER_GEN=1 \
+      -DFLETCHER_TESTS=0 \
       .. && \
     make && make install && \
     cd ../.. && rm -rf fletcher && \


### PR DESCRIPTION
This fixes the examples job in the Gitlab CI pipeline.