### PR TITLE
Re-add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,119 @@
+dist: xenial
+
+language: cpp
+
+branches:
+  only:
+    - master
+    - develop
+
+# cache: ccache
+
+# sudo: required
+# services:
+#   - docker
+
+env:
+  global:
+    # versions
+    - ARROW_VERSION=0.11.1
+    - AWS_FPGA_VERSION=1.4.4
+    - CAPI_SNAP_VERSION=1.5.1
+    - CAPI_PSLSE_VERSION=4.1
+    - PSLVER=8
+    # fletcher
+    - FLETCHER_CPP=0
+    - FLETCHER_ECHO=0
+    - FLETCHER_AWS=0
+    - FLETCHER_SNAP=0
+    - FLETCHER_GEN=0
+    - FLETCHER_PYTHON=0
+    - FLETCHER_TESTS=0
+    - SOURCE_PATH=
+    # cmake
+    - CTEST_OUTPUT_ON_FAILURE=1
+
+matrix:
+  include:
+    # all
+    - env: FLETCHER_CPP=1 FLETCHER_ECHO=1 FLETCHER_AWS=1 FLETCHER_SNAP=1 FLETCHER_GEN=1
+    # common
+    - env: SOURCE_PATH=common/cpp FLETCHER_TESTS=1
+    # runtime
+    - env: SOURCE_PATH=runtime/cpp FLETCHER_TESTS=1
+    - env: SOURCE_PATH=runtime/cpp FLETCHER_PYTHON=1
+    # codegen
+    - env: SOURCE_PATH=codegen/fletchgen
+    # snap platform
+    - env: SOURCE_PATH=platforms/snap/runtime FLETCHER_SNAP=1
+    # aws platform
+    - env: SOURCE_PATH=platforms/aws-f1/runtime FLETCHER_AWS=1
+    # echo platform
+    - env: SOURCE_PATH=platforms/echo/runtime
+
+before_install:
+  - curl -sSL "https://packages.red-data-tools.org/ubuntu/red-data-tools-keyring.gpg" | sudo -E apt-key add -
+  - echo "deb https://packages.red-data-tools.org/ubuntu/ xenial universe" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -yq libarrow-dev=${ARROW_VERSION}-1
+
+addons:
+  apt:
+    packages:
+      - libboost-all-dev
+
+script:
+  - |
+    if [ $FLETCHER_PYTHON -eq 1 ]; then
+      curl "https://bootstrap.pypa.io/get-pip.py" | sudo python3
+      sudo pip install cython numpy pyarrow==$ARROW_VERSION
+      export PYARROW_DIR=`python3 -c "import pyarrow as pa; print(pa.get_library_dirs()[0])"`
+    fi
+  - |
+    if [ $FLETCHER_AWS -eq 1 ]; then
+      git clone --single-branch --depth 1 --branch v$AWS_FPGA_VERSION https://github.com/aws/aws-fpga
+      pushd aws-fpga
+      source sdk_setup.sh
+      popd
+    fi
+  - |
+    if [ $FLETCHER_SNAP -eq 1 ]; then
+      git clone --single-branch --depth 1 --branch v$CAPI_PSLSE_VERSION https://github.com/ibm-capi/pslse
+      pushd pslse
+      export PSLSE_ROOT=`pwd`
+      popd
+      git clone --single-branch --depth 1 --branch v$CAPI_SNAP_VERSION https://github.com/open-power/snap
+      pushd snap
+      export SNAP_ROOT=`pwd`
+      BUILD_SIMCODE=1 make software
+      popd
+      fi
+  - mkdir -p build
+  - pushd build
+  - cmake
+    -DFLETCHER_CPP=$FLETCHER_CPP
+    -DFLETCHER_ECHO=$FLETCHER_ECHO
+    -DFLETCHER_AWS=$FLETCHER_AWS
+    -DFLETCHER_SNAP=$FLETCHER_SNAP
+    -DFLETCHER_GEN=$FLETCHER_GEN
+    -DFLETCHER_PYTHON=$FLETCHER_PYTHON
+    -DPYARROW_DIR=$PYARROW_DIR
+    -DFLETCHER_TESTS=$FLETCHER_TESTS
+    ../$SOURCE_PATH
+  - make -j
+  - |
+    if [ $FLETCHER_TESTS -eq 1 ]; then
+      make test
+    fi
+  - popd
+  - |
+    if [ "$FLETCHER_PYTHON" -ne 0 ]; then
+      pushd build
+      make install
+      popd
+      pushd runtime/python
+      sudo python3 setup.py install
+      sudo ldconfig
+      python3 testing/test.py
+      popd
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,20 +36,28 @@ env:
 matrix:
   include:
     # all
-    - env: FLETCHER_CPP=1 FLETCHER_ECHO=1 FLETCHER_AWS=1 FLETCHER_SNAP=1 FLETCHER_GEN=1
+    - name: "[C++] Fletcher"
+      env: FLETCHER_CPP=1 FLETCHER_ECHO=1 FLETCHER_AWS=1 FLETCHER_SNAP=1 FLETCHER_GEN=1
     # common
-    - env: SOURCE_PATH=common/cpp FLETCHER_TESTS=1
+    - name: "[C++] Common"
+      env: SOURCE_PATH=common/cpp FLETCHER_TESTS=1
     # runtime
-    - env: SOURCE_PATH=runtime/cpp FLETCHER_TESTS=1
-    - env: SOURCE_PATH=runtime/cpp FLETCHER_PYTHON=1
+    - name: "[C++] Runtime"
+      env: SOURCE_PATH=runtime/cpp FLETCHER_TESTS=1
+    - name: "[Python] pyfletcher"
+      env: SOURCE_PATH=runtime/cpp FLETCHER_PYTHON=1
     # codegen
-    - env: SOURCE_PATH=codegen/fletchgen
+    - name: "[C++] Fletchgen"
+      env: SOURCE_PATH=codegen/fletchgen
     # snap platform
-    - env: SOURCE_PATH=platforms/snap/runtime FLETCHER_SNAP=1
+    - name: "[C++] Snap platform"
+      env: SOURCE_PATH=platforms/snap/runtime FLETCHER_SNAP=1
     # aws platform
-    - env: SOURCE_PATH=platforms/aws-f1/runtime FLETCHER_AWS=1
+    - name: "[C++] AWS-F1 platform"
+      env: SOURCE_PATH=platforms/aws-f1/runtime FLETCHER_AWS=1
     # echo platform
-    - env: SOURCE_PATH=platforms/echo/runtime
+    - name: "[C++] Echo platform"
+      env: SOURCE_PATH=platforms/echo/runtime
 
 before_install:
   - curl -sSL "https://packages.red-data-tools.org/ubuntu/red-data-tools-keyring.gpg" | sudo -E apt-key add -

--- a/BuildGTest.cmake
+++ b/BuildGTest.cmake
@@ -1,0 +1,14 @@
+if (NOT TARGET gtest AND NOT TARGET gtest_main)
+  # Download and unpack googletest at configure time
+  configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in ${CMAKE_CURRENT_BINARY_DIR}/googletest-download/CMakeLists.txt)
+  execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download" )
+  execute_process(COMMAND "${CMAKE_COMMAND}" --build .
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download" )
+
+  # Add googletest directly to our build. This adds
+  # the following targets: gtest, gtest_main, gmock
+  # and gmock_main
+  add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+                   "${CMAKE_CURRENT_BINARY_DIR}/googletest-build" EXCLUDE_FROM_ALL)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ option(FLETCHER_TESTS "Build tests." ON)
 
 if (FLETCHER_TESTS)
   enable_testing()
+  include(BuildGTest.cmake)
 endif()
 
 ########################################################################################################################

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mbrobbel/libarrow:$ARROW_VERSION
 
 LABEL fletcher=
 
-ENV BUILD_PACKAGES cmake g++
+ENV BUILD_PACKAGES cmake g++ git
 
 WORKDIR fletcher
 ADD . .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Fletcher: A framework to integrate FPGA accelerators with Apache Arrow
 
+[![Build Status](https://travis-ci.org/johanpel/fletcher.svg?branch=master)](https://travis-ci.org/johanpel/fletcher)
 [![pipeline status](https://gitlab.com/mbrobbel/fletcher/badges/master/pipeline.svg)](https://gitlab.com/mbrobbel/fletcher/commits/master)
 
 Fletcher is a framework that helps to integrate FPGA accelerators with tools and

--- a/common/cpp/CMakeLists.txt
+++ b/common/cpp/CMakeLists.txt
@@ -59,11 +59,7 @@ if (FLETCHER_TESTS)
     target_link_libraries(${TEST_GEN} ${LIB_ARROW})
     target_link_libraries(${TEST_GEN} ${FLETCHER_COMMON})
 
-    # Common library unit tests
-
-    # Include GoogleTest CMake functionality
-    include(GoogleTest)
-    find_package(GTest REQUIRED)
+    include(../../BuildGTest.cmake)
 
     # Test common library functions
     set(TEST_COMMON fletcher-test-common)
@@ -75,9 +71,10 @@ if (FLETCHER_TESTS)
             ${TEST_COMMON_HEADERS} ${TEST_COMMON_SOURCES})
     target_link_libraries(${TEST_COMMON} ${LIB_ARROW})
     target_link_libraries(${TEST_COMMON} ${FLETCHER_COMMON})
-    target_link_libraries(${TEST_COMMON} GTest::GTest GTest::Main)
+    target_link_libraries(${TEST_COMMON} gtest gtest_main)
     include_directories(${TEST_COMMON} src)
 
+    include(GoogleTest)
     gtest_discover_tests(${TEST_COMMON})
 
 endif (FLETCHER_TESTS)

--- a/runtime/cpp/CMakeLists.txt
+++ b/runtime/cpp/CMakeLists.txt
@@ -108,16 +108,15 @@ if (FLETCHER_TESTS)
       set(FLETCHER_ECHO_LIBDIR ${CMAKE_BINARY_DIR}/echo)
     endif ()
 
-    # Include GoogleTest CMake functionality
-    include(GoogleTest)
-    find_package(GTest REQUIRED)
+    include(../../BuildGTest.cmake)
 
     set(TEST_SOURCES test/test.cpp)
     add_executable(${FLETCHER}-test ${TEST_HEADERS} ${TEST_SOURCES})
     target_link_libraries(${FLETCHER}-test ${FLETCHER})
     target_link_libraries(${FLETCHER}-test ${LIB_ARROW})
-    target_link_libraries(${FLETCHER}-test GTest::GTest GTest::Main)
+    target_link_libraries(${FLETCHER}-test gtest gtest_main)
     target_include_directories(${FLETCHER}-test PUBLIC ../../platforms/echo/runtime/src)
 
+    include(GoogleTest)
     gtest_discover_tests(${FLETCHER}-test PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${FLETCHER_ECHO_LIBDIR}")
 endif (FLETCHER_TESTS)


### PR DESCRIPTION
Currently the Gitlab pipeline doesn't run for pull requests from forks (https://gitlab.com/gitlab-org/gitlab-ee/issues/5667). 
This PR re-adds a Travis file to make sure we also run some CI jobs for pull requests from forks.

I also included googletest in our cmake project as this is the recommend way: https://github.com/abseil/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project