### PR TITLE
Bump Arrow from 0.12 to 0.13

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 Dockerfile
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 env:
   global:
     # versions
-    - ARROW_VERSION=0.12.0
+    - ARROW_VERSION=0.13.0
     - AWS_FPGA_VERSION=1.4.5
     - CAPI_SNAP_VERSION=1.5.1
     - CAPI_PSLSE_VERSION=4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ARROW_VERSION=0.12.1
+ARG ARROW_VERSION=0.13.0
 FROM mbrobbel/libarrow:$ARROW_VERSION
 
 LABEL fletcher=


### PR DESCRIPTION
[Changelog](https://arrow.apache.org/release/0.13.0.html)
[Release blog post](https://arrow.apache.org/blog/2019/04/02/0.13.0-release/)