### PR TITLE
Bump aws-fpga from 1.4.4 to 1.4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     # versions
     - ARROW_VERSION=0.13.0
-    - AWS_FPGA_VERSION=1.4.5
+    - AWS_FPGA_VERSION=1.4.8
     - CAPI_SNAP_VERSION=1.5.1
     - CAPI_PSLSE_VERSION=4.1
     - PSLVER=8


### PR DESCRIPTION
[Release notes 1.4.8](https://github.com/aws/aws-fpga/blob/master/RELEASE_NOTES.md#release-148-see-errata-for-unsupported-features)
[Release notes 1.4.7](https://github.com/aws/aws-fpga/blob/master/RELEASE_NOTES.md#release-147-see-errata-for-unsupported-features)
[Release notes 1.4.6](https://github.com/aws/aws-fpga/blob/master/RELEASE_NOTES.md#release-146-see-errata-for-unsupported-features)
[Release notes 1.4.5](https://github.com/aws/aws-fpga/blob/master/RELEASE_NOTES.md#release-145-see-errata-for-unsupported-features)
