### PR TITLE
fix for index overflow in BufferReaderCmdGenBusReq

### DIFF
--- a/hardware/buffers/BufferReaderCmdGenBusReq.vhd
+++ b/hardware/buffers/BufferReaderCmdGenBusReq.vhd
@@ -185,7 +185,9 @@ begin
   last_index                    <= align_aeq(r.index.last, log2floor(ELEMS_PER_STEP));
 
   -- Get the byte address of this index
-  byte_address                  <= r.base_address + shift_left_with_neg(r.index.current, ITOBA_LSHIFT);
+  byte_address                  <= r.base_address + shift_left_with_neg(
+      resize(r.index.current, r.index.current'length + work.Utils.max(0, ITOBA_LSHIFT)),
+      ITOBA_LSHIFT);
 
   -----------------------------------------------------------------------------
   -- State machine sequential part


### PR DESCRIPTION
Fix for index overflow in BufferReaderCmdGenBusReq for large indices and positive shift.

The left shift by `ITOBA_LSHIFT`, determined by the element size, can overflow when the used indices need the `ITOBA_LSHIFT` most significant bits.

This can be fixed by resizing before shifting (as done here), or by changing the shift function in `Util` to return a larger vector.