### PR TITLE
Fix array reader gen_tb.py path when seed is specified manually

### DIFF
--- a/hardware/arrays/test/arrayreader/questa/ArrayReader.tcl
+++ b/hardware/arrays/test/arrayreader/questa/ArrayReader.tcl
@@ -10,7 +10,7 @@ proc gen_cr {{seed -1}} {
     exec python3 ../gen_tb.py > ArrayReader_tb.vhd
   } else {
     echo "Seed = $seed"
-    exec python3 gen_tb.py $seed > ArrayReader_tb.vhd
+    exec python3 ../gen_tb.py $seed > ArrayReader_tb.vhd
   }
   
   add_source ArrayReader_tb.vhd


### PR DESCRIPTION
When calling `gen_cr` manually with a specific seed, a different branch is used to locate the `gen_tb.py` script, which was not updated during refactoring.