### PR TITLE
Update travis badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: xenial
 
 language: cpp
 
-branches:
-  only:
-    - master
-    - develop
-
 env:
   global:
     # versions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fletcher: A framework to integrate FPGA accelerators with Apache Arrow
 
-[![Build Status](https://travis-ci.org/johanpel/fletcher.svg?branch=master)](https://travis-ci.org/johanpel/fletcher)
+[![Build Status](https://travis-ci.com/abs-tudelft/fletcher.svg?branch=develop)](https://travis-ci.com/abs-tudelft/fletcher)
 [![pipeline status](https://gitlab.com/mbrobbel/fletcher/badges/master/pipeline.svg)](https://gitlab.com/mbrobbel/fletcher/commits/master)
 
 Fletcher is a framework that helps to integrate FPGA accelerators with tools and


### PR DESCRIPTION
Repository move to abs-tudelft organization disabled Travis-CI builds. I just replaced the .org travis integration with .com Github app integration. This PR updates the badge.

Gitlab build integration is also broken, but I'm planning to replace that with something else as the integration will be removed from the free tier. More info [here](https://about.gitlab.com/solutions/github/#pricing).

> For GitLab.com users, GitLab CI/CD for GitHub will be available promotionally in our Free tier through September 22, 2019. (After September 22, 2019 it will move to the Silver tier and be available on Silver and Gold.)