### PR TITLE
fix AXI MMIO reset on blank REG_RESET string

### DIFF
--- a/hardware/axi/axi_mmio.vhd
+++ b/hardware/axi/axi_mmio.vhd
@@ -211,8 +211,8 @@ begin
               end if;
           end loop;
         else
-          for I in REG_RESET'range loop
-            r.regs(i-REG_RESET'low) <= (others => '0');
+          for I in r.regs'range loop
+            r.regs(i) <= (others => '0');
           end loop;
         end if;
       end if;

--- a/hardware/axi/axi_mmio.vhd
+++ b/hardware/axi/axi_mmio.vhd
@@ -206,13 +206,13 @@ begin
         -- Check for each register if it needs to be reset
         if (REG_RESET /= "") then
           for I in REG_RESET'range loop
-              if (REG_RESET(i) /= 'Y') then
-                r.regs(i-REG_RESET'low) <= (others => '0');
+              if (REG_RESET(I) /= 'Y') then
+                r.regs(I-REG_RESET'low) <= (others => '0');
               end if;
           end loop;
         else
           for I in r.regs'range loop
-            r.regs(i) <= (others => '0');
+            r.regs(I) <= (others => '0');
           end loop;
         end if;
       end if;


### PR DESCRIPTION
Since REG_RESET'range is a null range when using the default empty string for REG_RESET, none of the register are reset when reset_n is de-asserted. This commit restores the expected behaviour, which is to reset all registers when the empty string is given as argument.