### PR TITLE
Add Cython language_level directive. Remove unicode string literals.

### DIFF
--- a/runtime/python/pyfletcher/includes/libfletcher.pxd
+++ b/runtime/python/pyfletcher/includes/libfletcher.pxd
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # distutils: language = c++
+# cython: language_level=3
 
 cimport cython
 

--- a/runtime/python/pyfletcher/lib.pyx
+++ b/runtime/python/pyfletcher/lib.pyx
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # distutils: language = c++
+# cython: language_level=3
 
 import cython
 import pyarrow

--- a/runtime/python/pyfletcher/platform.pxi
+++ b/runtime/python/pyfletcher/platform.pxi
@@ -30,13 +30,13 @@ cdef class Platform:
     cdef:
         shared_ptr[CPlatform] platform
 
-    def __init__(self, str name = u"", quiet = True):
+    def __init__(self, str name = "", quiet = True):
         self._create(name, quiet)
 
     cdef from_pointer(self, const shared_ptr[CPlatform]& platform):
         self.platform = platform
 
-    cdef _create(self, str name = u"", quiet = True):
+    cdef _create(self, str name = "", quiet = True):
         if not name:
             check_fletcher_status(CPlatform.createUnnamed(&self.platform))
         else:
@@ -58,7 +58,7 @@ cdef class Platform:
         """
         check_fletcher_status(self.platform.get().WriteMMIO(offset, value))
 
-    def read_mmio(self, uint64_t offset, str type=u"uint"):
+    def read_mmio(self, uint64_t offset, str type="uint"):
         """Read from MMIO register.
 
 
@@ -82,7 +82,7 @@ cdef class Platform:
         else:
             raise ValueError("Invalid type in read_mmio(). Options: 'uint' (default), 'int' or 'float'")
 
-    def read_mmio_64(self, uint64_t offset, str type=u"uint"):
+    def read_mmio_64(self, uint64_t offset, str type="uint"):
         """Read 64 bit value from two 32 bit MMIO registers.
 
 


### PR DESCRIPTION
The fix applied to the string literals in platform.pxi in https://github.com/abs-tudelft/fletcher/commit/c726bf13f581898a9cd8fb5b80f7d0847194de93 was wrong. The correct way to solve that issue is to set the Cython `language_level` directive:

```
[1/1] Cythonizing pyfletcher/lib.pyx
/usr/local/lib/python3.7/dist-packages/Cython/Compiler/Main.py:367: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /usr/src/app/pyfletcher/lib.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
```

This PR reverts the fix applied in https://github.com/abs-tudelft/fletcher/commit/c726bf13f581898a9cd8fb5b80f7d0847194de93 and sets the `language_level` directive to 3.