### PR TITLE
Vivado HLS header changes and additions

### DIFF
--- a/codegen/test/sodabeer/hls/src/SodaBeer.cpp
+++ b/codegen/test/sodabeer/hls/src/SodaBeer.cpp
@@ -1,4 +1,4 @@
-#include "fletcher/vivado_hls.h"
+
 
 #include "SodaBeer.h"
 
@@ -6,16 +6,25 @@ bool ChooseDrink(RecordBatchMeta hobbits_meta, Hobbits& hobbits, Soda& soda, Bee
 	#pragma HLS INTERFACE register port=beer_allowed_age
 	#pragma HLS INTERFACE register port=hobbits_meta.length
 
+#pragma HLS INTERFACE ap_fifo port=hobbits.name_length
 	#pragma HLS data_pack variable=hobbits.name_length
+#pragma HLS INTERFACE ap_fifo port=hobbits.name_chars
 	#pragma HLS data_pack variable=hobbits.name_chars
+#pragma HLS INTERFACE ap_fifo port=hobbits.age
 	#pragma HLS data_pack variable=hobbits.age
 
+#pragma HLS INTERFACE ap_fifo port=soda.name_length
 	#pragma HLS data_pack variable=soda.name_length
+#pragma HLS INTERFACE ap_fifo port=soda.name_chars
 	#pragma HLS data_pack variable=soda.name_chars
+#pragma HLS INTERFACE ap_fifo port=soda.age
 	#pragma HLS data_pack variable=soda.age
 
+#pragma HLS INTERFACE ap_fifo port=beer.name_length
 	#pragma HLS data_pack variable=beer.name_length
+#pragma HLS INTERFACE ap_fifo port=beer.name_chars
 	#pragma HLS data_pack variable=beer.name_chars
+#pragma HLS INTERFACE ap_fifo port=beer.age
 	#pragma HLS data_pack variable=beer.age
 
 	static int i = 0;

--- a/codegen/test/sodabeer/hls/src/fletcher/vivado_hls.h
+++ b/codegen/test/sodabeer/hls/src/fletcher/vivado_hls.h
@@ -3,14 +3,17 @@
 #include <hls_stream.h>
 #include <ap_int.h>
 
+// A log function to get the number of count bits.
+template <int x>
+ struct f_log2 { enum { value = 1 + f_log2<x/2>::value }; };
+template <> struct f_log2<1> { enum { value = 1 }; };
+
 /**
  * Stream packet structs and types corresponding to Fletcher / Arrow types.
  */
 
 /// @brief Base packet containing count, dvalid and last.
-template<unsigned int C>
 struct f_packet_base {
-	ap_uint<C> 	count 	= 1;
 	bool 		dvalid 	= true;
 	bool 		last 	= false;
 
@@ -24,43 +27,122 @@ struct f_packet_base {
 };
 
 /// @brief Packet for signed integers.
-template<unsigned int W, unsigned int C>
-struct f_spacket : public f_packet_base<C> {
+template<unsigned int W>
+struct f_spacket : public f_packet_base {
 	ap_int<W> data = 0;
 };
 
 /// @brief Packet for unsigned integers.
-template<unsigned int W, unsigned int C>
-struct f_upacket : public f_packet_base<C> {
+template<unsigned int W>
+struct f_upacket : public f_packet_base {
 	ap_uint<W> data = 0;
 };
 
-/// TODO(johanpel): packet for floats
+/// @brief Packet for half precision floats.
+struct f_hpacket : public f_packet_base {
+	half data = 0.0f;
+};
+
+/// @brief Packet for single precision floats.
+struct f_fpacket : public f_packet_base {
+	float data = 0.0f;
+};
+
+/// @brief Packet for double precision floats.
+struct f_dpacket : public f_packet_base {
+	double data = 0.0;
+};
+
+/// @brief Packet for signed integers for multiple element per cycle.
+template<unsigned int W, unsigned int N>
+struct f_mspacket : public f_packet_base {
+	ap_uint<f_log2<N>::value> count = N; // For true minimum use N-1
+	ap_int<W> data[N];
+};
+
+/// @brief Packet for unsigned integers for multiple element per cycle..
+template<unsigned int W, unsigned int N>
+struct f_mupacket : public f_packet_base {
+	ap_uint<f_log2<N>::value> count = N; // For true minimum use N-1
+	ap_uint<W> data[N];
+};
+
+/// @brief Packet for half precision floats for multiple element per cycle.
+template<unsigned int N>
+struct f_mhpacket : public f_packet_base {
+	ap_uint<f_log2<N>::value> count = N; // For true minimum use N-1
+	half data[N];
+};
+
+/// @brief Packet for single precision floats for multiple element per cycle.
+template<unsigned int N>
+struct f_mfpacket : public f_packet_base {
+	ap_uint<f_log2<N>::value> count = N; // For true minimum use N-1
+	float data[N];
+};
+
+/// @brief Packet for double precision floats for multiple element per cycle..
+template<unsigned int N>
+struct f_mdpacket : public f_packet_base {
+	ap_uint<f_log2<N>::value> count = N; // For true minimum use N-1
+	double data[N];
+};
 
 /// @brief Wrapper for nullable types
-template<class T>
+template<typename T>
 struct nullable : public T {
-	bool null = false;
+	bool valid = true;
 };
 
 // Lengths, offsets
-typedef f_spacket<32,1> f_size;
+
+typedef f_spacket<32> f_size;
 
 // Arrow primitive types:
-typedef f_upacket< 1,1> f_bool;
-typedef f_spacket< 8,1> f_int8;
-typedef f_spacket<16,1> f_int16;
-typedef f_spacket<32,1> f_int32;
-typedef f_spacket<64,1> f_int64;
-typedef f_upacket< 8,1> f_uint8;
-typedef f_upacket<16,1> f_uint16;
-typedef f_upacket<32,1> f_uint32;
-typedef f_upacket<64,1> f_uint64;
-typedef f_upacket<16,1> f_float16;
-typedef f_upacket<32,1> f_float32;
-typedef f_upacket<64,1> f_float64;
-typedef f_upacket<32,1> f_date32;
-typedef f_upacket<64,1> f_date64;
+struct f_bool : f_upacket< 1> {};
+struct f_int8 : f_spacket< 8> {};
+struct f_int16 :  f_spacket<16> {};
+struct f_int32 :  f_spacket<32> {};
+struct f_int64 :  f_spacket<64> {};
+struct f_uint8 :  f_upacket< 8> {};
+struct f_uint16 :  f_upacket<16> {};
+struct f_uint32 :  f_upacket<32> {};
+struct f_uint64 :  f_upacket<64> {};
+struct f_float16 :  f_hpacket     {};
+struct f_float32 :  f_fpacket     {};
+struct f_float64 :  f_dpacket     {};
+struct f_date32 :  f_upacket<32> {};
+struct f_date64 :  f_upacket<64> {};
+
+// Arrow primitive list types:
+template<unsigned int N>
+struct f_mbool : f_mupacket< 1, N> {};
+template<unsigned int N>
+struct f_mint8 : f_mspacket< 8, N> {};
+template<unsigned int N>
+struct f_mint16 : f_mspacket<16, N> {};
+template<unsigned int N>
+struct f_mint32 : f_mspacket<32, N> {};
+template<unsigned int N>
+struct f_mint64 : f_mspacket<64, N> {};
+template<unsigned int N>
+struct f_muint8 : f_mupacket< 8, N> {};
+template<unsigned int N>
+struct f_muint16 : f_mupacket<16, N> {};
+template<unsigned int N>
+struct f_muint32 : f_mupacket<32, N> {};
+template<unsigned int N>
+struct f_muint64 : f_mupacket<64, N> {};
+template<unsigned int N>
+struct f_mfloat16 : f_mhpacket<N> {};
+template<unsigned int N>
+struct f_mfloat32 : f_mfpacket<N> {};
+template<unsigned int N>
+struct f_mfloat64 : f_mdpacket<N> {};
+template<unsigned int N>
+struct f_mdate32 : f_mupacket<32, N> {};
+template<unsigned int N>
+struct f_mdate64 : f_mupacket<64, N> {};
 
 /**
  * RecordBatch & Schema support


### PR DESCRIPTION
I would say this is fairly far along to "testable".

**Main Changes**
Added back the explicit ap_fifo port pragma's.
Added multi element support and the respective types.
Switched null flag to valid flag as per the Arrow Spec.
Added half, float, double packets. (W is fixed at 16, 32 of 64)

**Extra info**
Base packet types naming template:
`f_[m]?[ushfd]packet`

Types naming template
`f_[m]?{arrowtypename}`

`m` signifies multi type, this adds one unsigned int template parameter.
`u`, `s`, `h`, `f`, `d` signify the base type, resp.: `ap_uint`, `ap_int`, `half`, `float`, `double`

Nullable types are wrapped in `nullable<..>`.

The output is currently:

| **Field**   |  **Bits**  | **Notes**  |
|---|---|---|
|  dvalid  |  1  |   |
|  last  |  1  |   |
|  count  |  2log(N) |  Only for multi types |
|  data  |  W  |  Only for non multi types  |
|  data[0..N-1]  | W*N  |  Only for multi types  |
|  valid  | 1  |  Only for nullable types  |

To connect the output properly to the rest of the system, bus information is in `auxiliary.xml`, given that new or other versions of Vivado HLS might change the backend and reorder the outputs, it's important to ingest that data from the file.

Here is an example:
```cpp
bool func(hls::stream<f_muint8<8> > string, hls::stream<nullable<f_uint8> > nullable_uint8, hls::stream<f_int32 > basic);
```

```xml
<xd:arg xd:name="string.dvalid" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="0:0" xd:dataWidth="1"/>
<xd:arg xd:name="string.last" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="1:1" xd:dataWidth="1"/>
<xd:arg xd:name="string.count" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="5:2" xd:dataWidth="4"/>
<xd:arg xd:name="string.data[0]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="13:6" xd:dataWidth="8"/>
<xd:arg xd:name="string.data[1]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="21:14" xd:dataWidth="8"/>
<xd:arg xd:name="string.data[2]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="29:22" xd:dataWidth="8"/>
<xd:arg xd:name="string.data[3]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="37:30" xd:dataWidth="8"/>
<xd:arg xd:name="string.data[4]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="45:38" xd:dataWidth="8"/>
<xd:arg xd:name="string.data[5]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="53:46" xd:dataWidth="8"/>
<xd:arg xd:name="string.data[6]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="61:54" xd:dataWidth="8"/>
<xd:arg xd:name="string.data[7]" xd:originalName="string" xd:direction="in" xd:interfaceRef="string_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="69:62" xd:dataWidth="8"/>
<xd:arg xd:name="nullable_uint8.dvalid" xd:originalName="nullable_uint8" xd:direction="in" xd:interfaceRef="nullable_uint8_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="0:0" xd:dataWidth="1"/>
<xd:arg xd:name="nullable_uint8.last" xd:originalName="nullable_uint8" xd:direction="in" xd:interfaceRef="nullable_uint8_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="1:1" xd:dataWidth="1"/>
<xd:arg xd:name="nullable_uint8.data" xd:originalName="nullable_uint8" xd:direction="in" xd:interfaceRef="nullable_uint8_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="9:2" xd:dataWidth="8"/>
<xd:arg xd:name="nullable_uint8.valid" xd:originalName="nullable_uint8" xd:direction="in" xd:interfaceRef="nullable_uint8_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="10:10" xd:dataWidth="1"/>
<xd:arg xd:name="basic.dvalid" xd:originalName="basic" xd:direction="in" xd:interfaceRef="basic_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="0:0" xd:dataWidth="1"/>
<xd:arg xd:name="basic.last" xd:originalName="basic" xd:direction="in" xd:interfaceRef="basic_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="1:1" xd:dataWidth="1"/>
<xd:arg xd:name="basic.data" xd:originalName="basic" xd:direction="in" xd:interfaceRef="basic_V" xd:busTypeRef="acc_fifo" xd:dataPack="true" xd:bitMapping="33:2" xd:dataWidth="32"/>
```

This format is very simple, one root element and then a list of childs. As for constraints, check for that `acc_fifo` `busTypeRef`, the field names, the dataWidth and bitMapping. If they do not agree error out.
