### PR TITLE
Add nullable testbench struct plus conversion constructors. Added operators to packet.

### DIFF
--- a/integrations/vivado_hls/src/fletcher/api.h
+++ b/integrations/vivado_hls/src/fletcher/api.h
@@ -81,27 +81,27 @@ struct f_packet : public f_packet_base
 	}
 	friend f_packet<T> operator+(f_packet<T> &lhs, f_packet<T> &rhs)
 	{
-		return f_packet<T>(lhs.data + rhs.data);
+		return f_packet<T>(lhs.data + rhs.data, lhs.dvalid, lhs.last);
 	}
 	friend f_packet<T> operator+(f_packet<T> &rhs)
 	{
-		return f_packet<T>(+rhs.data);
+		return f_packet<T>(+rhs.data, rhs.dvalid, rhs.last);
 	}
 	friend f_packet<T> operator-(f_packet<T> &lhs, f_packet<T> &rhs)
 	{
-		return f_packet<T>(lhs.data - rhs.data);
+		return f_packet<T>(lhs.data - rhs.data, lhs.dvalid, lhs.last);
 	}
 	friend f_packet<T> operator-(f_packet<T> &rhs)
 	{
-		return f_packet<T>(-rhs.data);
+		return f_packet<T>(-rhs.data, rhs.dvalid, rhs.last);
 	}
 	friend f_packet<T> operator*(f_packet<T> &lhs, f_packet<T> &rhs)
 	{
-		return f_packet<T>(lhs.data * rhs.data);
+		return f_packet<T>(lhs.data * rhs.data, lhs.dvalid, lhs.last);
 	}
 	friend f_packet<T> operator/(f_packet<T> &lhs, f_packet<T> &rhs)
 	{
-		return f_packet<T>(lhs.data / rhs.data);
+		return f_packet<T>(lhs.data / rhs.data, lhs.dvalid, lhs.last);
 	}
 	friend bool operator==(f_packet<T> &lhs, f_packet<T> &rhs)
 	{
@@ -178,6 +178,8 @@ struct nullable : public T
 	nullable(bool _valid,Args &&... args) : T(std::forward<Args>(args)...), valid(_valid) {}
 
 	nullable(bool _valid) : T(), valid(_valid) {}
+
+	nullable(bool _valid, nullable<T> _nullable) : T(_nullable.data, _nullable.dvalid, _nullable.last), valid(_valid) {}
 
 	template <typename IT>
 	nullable(nullable_tb<IT> _nullable_tb) : T(_nullable_tb.data), valid(_nullable_tb.valid) {}

--- a/integrations/vivado_hls/src/fletcher/api.h
+++ b/integrations/vivado_hls/src/fletcher/api.h
@@ -1,266 +1,30 @@
 #pragma once
 
-#include <hls_stream.h>
 #include <ap_int.h>
 #include <hls_half.h>
-#include <utility>
-#include <string.h>
 
-// A log function to get the number of count bits.
-template <int x>
-struct f_log2
-{
-	enum
-	{
-		value = 1 + f_log2<x / 2>::value
-	};
-};
-template <>
-struct f_log2<1>
-{
-	enum
-	{
-		value = 1
-	};
-};
+#include <string.h>
 
 /**
  * Stream packet structs and types corresponding to Fletcher / Arrow types.
  */
 
-/// @brief Base packet containing count, dvalid and last.
-struct f_packet_base
-{
-	bool dvalid = true;
-	bool last = false;
+#include "components/helpers.h"
 
-	void SetDataValid(bool val)
-	{
-		dvalid = val;
-	}
+#include "components/packet_base.h"
 
-	bool DataValid()
-	{
-		return dvalid;
-	}
+#include "components/packet.h"
 
-	f_packet_base() = default;
+#include "components/mpacket.h"
 
-	f_packet_base(bool _dvalid, bool _last) : dvalid(_dvalid), last(_last) {}
-};
+#include "components/types.h"
 
-/// @brief Packet template.
-template <typename T>
-struct f_packet : public f_packet_base
-{
-	T data = 0;
-	f_packet() = default;
-	f_packet(T _data) : data(_data), f_packet_base() {}
-	f_packet(T _data, bool dvalid, bool last) : data(_data), f_packet_base(dvalid, last) {}
+#include "components/nullable.h"
 
-	friend bool operator<(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return lhs.data < rhs.data;
-	}
-	f_packet<T> &operator=(const T val)
-	{
-		data = val;
-		return *this;
-	}
-	friend bool operator>(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return rhs < lhs;
-	}
-	friend bool operator<=(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return !(rhs < lhs);
-	}
-	friend bool operator>=(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return !(lhs < rhs);
-	}
-	friend f_packet<T> operator+(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return f_packet<T>(lhs.data + rhs.data, lhs.dvalid, lhs.last);
-	}
-	friend f_packet<T> operator+(f_packet<T> &rhs)
-	{
-		return f_packet<T>(+rhs.data, rhs.dvalid, rhs.last);
-	}
-	friend f_packet<T> operator-(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return f_packet<T>(lhs.data - rhs.data, lhs.dvalid, lhs.last);
-	}
-	friend f_packet<T> operator-(f_packet<T> &rhs)
-	{
-		return f_packet<T>(-rhs.data, rhs.dvalid, rhs.last);
-	}
-	friend f_packet<T> operator*(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return f_packet<T>(lhs.data * rhs.data, lhs.dvalid, lhs.last);
-	}
-	friend f_packet<T> operator/(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return f_packet<T>(lhs.data / rhs.data, lhs.dvalid, lhs.last);
-	}
-	friend bool operator==(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return lhs.data == rhs.data;
-	}
-	friend bool operator!=(f_packet<T> &lhs, f_packet<T> &rhs)
-	{
-		return !(rhs == lhs);
-	}
-};
-
-/// @brief Packet template (multi).
-template <typename T, unsigned int N>
-struct f_mpacket : public f_packet_base
-{
-	ap_uint<f_log2<N>::value> count = N; // For true minimum use N-1
-	T data[N];
-	f_mpacket() = default;
-	f_mpacket(T _data[N]) : data(_data), f_packet_base() {}
-};
-
-/// @brief Packet for signed integers.
-template <unsigned int W>
-using f_spacket = f_packet<ap_int<W>>;
-
-/// @brief Packet for unsigned integers.
-template <unsigned int W>
-using f_upacket = f_packet<ap_uint<W>>;
-
-/// @brief Packet for half precision floats.
-using f_hpacket = f_packet<half>;
-
-/// @brief Packet for single precision floats.
-using f_fpacket = f_packet<float>;
-
-/// @brief Packet for double precision floats.
-using f_dpacket = f_packet<double>;
-
-/// @brief Packet for signed integers for multiple element per cycle.
-template <unsigned int W, unsigned int N>
-using f_mspacket = f_mpacket<ap_int<W>, N>;
-
-/// @brief Packet for unsigned integers for multiple element per cycle..
-template <unsigned int W, unsigned int N>
-using f_mupacket = f_mpacket<ap_uint<W>, N>;
-
-/// @brief Packet for half precision floats for multiple element per cycle.
-template <unsigned int N>
-using f_mhpacket = f_mpacket<half, N>;
-
-/// @brief Packet for single precision floats for multiple element per cycle.
-template <unsigned int N>
-using f_mfpacket = f_mpacket<float, N>;
-
-/// @brief Packet for double precision floats for multiple element per cycle..
-template <unsigned int N>
-using f_mdpacket = f_mpacket<double, N>;
-
-//Add valid bit at the end, because data packing in vivado flips the order, and in hardware it needs to be the most significant bit.
-template <typename T>
-struct nullable_tb {   
-   T data;
-   bool valid;
-};
-// Lengths, offsets
-
-/// @brief Wrapper for nullable types
-template <typename T>
-struct nullable : public T
-{
-	bool valid = true;
-
-	template <typename... Args>
-	nullable(bool _valid,Args &&... args) : T(std::forward<Args>(args)...), valid(_valid) {}
-
-	nullable(bool _valid) : T(), valid(_valid) {}
-
-	nullable(bool _valid, nullable<T> _nullable) : T(_nullable.data, _nullable.dvalid, _nullable.last), valid(_valid) {}
-
-	template <typename IT>
-	nullable(nullable_tb<IT> _nullable_tb) : T(_nullable_tb.data), valid(_nullable_tb.valid) {}
-
-	template <typename IT>
-	nullable(nullable_tb<IT> _nullable_tb, bool _dvalid, bool _last) : T(_nullable_tb.data, _dvalid, _last), valid(_nullable_tb.valid) {}
-
-	nullable() = default;
-};
-
-using f_size = f_spacket<32>;
-
-// Arrow primitive types:
-using f_bool = f_upacket<1>;
-using f_int8 = f_spacket<8>;
-using f_int16 = f_spacket<16>;
-using f_int32 = f_spacket<32>;
-using f_int64 = f_spacket<64>;
-using f_uint8 = f_upacket<8>;
-using f_uint16 = f_upacket<16>;
-using f_uint32 = f_upacket<32>;
-using f_uint64 = f_upacket<64>;
-using f_float16 = f_hpacket;
-using f_float32 = f_fpacket;
-using f_float64 = f_dpacket;
-using f_date32 = f_upacket<32>;
-using f_date64 = f_upacket<64>;
-
-// Arrow primitive list types:
-template <unsigned int N>
-using f_mbool = f_mupacket<1, N>;
-template <unsigned int N>
-using f_mint8 = f_mspacket<8, N>;
-template <unsigned int N>
-using f_mint16 = f_mspacket<16, N>;
-template <unsigned int N>
-using f_mint32 = f_mspacket<32, N>;
-template <unsigned int N>
-using f_mint64 = f_mspacket<64, N>;
-template <unsigned int N>
-using f_muint8 = f_mupacket<8, N>;
-template <unsigned int N>
-using f_muint16 = f_mupacket<16, N>;
-template <unsigned int N>
-using f_muint32 = f_mupacket<32, N>;
-template <unsigned int N>
-using f_muint64 = f_mupacket<64, N>;
-template <unsigned int N>
-using f_mfloat16 = f_mhpacket<N>;
-template <unsigned int N>
-using f_mfloat32 = f_mfpacket<N>;
-template <unsigned int N>
-using f_mfloat64 = f_mdpacket<N>;
-template <unsigned int N>
-using f_mdate32 = f_mupacket<32, N>;
-template <unsigned int N>
-using f_mdate64 = f_mupacket<64, N>;
-
-//Strings
-using f_string = f_uint8 *;
-
-/// @brief Utility function to create f_string arrays from const char arrays.
-// f_string new_f_string(const char *src)
-// {
-// 	int len = strlen(src);
-// 	f_string str = new f_uint8[len];
-// 	for (int i = 0; i < len; i++)
-// 	{
-// 		str[i].data = src[i];
-// 	}
-// 	str[len - 1].last = true;
-
-// 	return str;
-// }
+#include "components/operators.h"
 
 /**
  * RecordBatch & Schema support
  */
 
-/// @brief RecordBatch metadata.
-struct RecordBatchMeta
-{
-	unsigned int length;
-};
+#include "components/meta.h"

--- a/integrations/vivado_hls/src/fletcher/components/helpers.h
+++ b/integrations/vivado_hls/src/fletcher/components/helpers.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// A log function to get the number of count bits.
+template <int x>
+struct f_log2
+{
+    enum
+    {
+        value = 1 + f_log2<x / 2>::value
+    };
+};
+template <>
+struct f_log2<1>
+{
+    enum
+    {
+        value = 1
+    };
+};
+
+#include <tuple>
+#include <type_traits>
+
+template<typename T>
+struct innermost_impl
+{
+    using type = T;
+};
+
+template<template<typename> class E, typename T>
+struct innermost_impl<E<T>>
+{
+    using type = typename innermost_impl<T>::type;
+};
+
+template<template<typename...> class E, typename... Ts>
+struct innermost_impl<E<Ts...>>
+{
+    using type = std::tuple<typename innermost_impl<Ts>::type...>;
+};
+
+template<typename T>
+using innermost = typename innermost_impl<T>::type;

--- a/integrations/vivado_hls/src/fletcher/components/meta.h
+++ b/integrations/vivado_hls/src/fletcher/components/meta.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "types.h"
+
+/// @brief RecordBatch metadata.
+struct RecordBatchMeta
+{
+    f_base_length_type length;
+};

--- a/integrations/vivado_hls/src/fletcher/components/mpacket.h
+++ b/integrations/vivado_hls/src/fletcher/components/mpacket.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "packet.h"
+
+/// @brief Packet template (multi).
+template <typename T, unsigned int N>
+struct f_mpacket : public f_packet_base
+{
+    ap_uint<f_log2<N>::value> count = N; // For true minimum use N-1
+    T data[N];
+    f_mpacket() = default;
+    f_mpacket(T _data[N]) : data(_data), f_packet_base() {}
+};

--- a/integrations/vivado_hls/src/fletcher/components/nullable.h
+++ b/integrations/vivado_hls/src/fletcher/components/nullable.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <utility>
+//Add valid bit at the end, because data packing in vivado flips the order, and in hardware it needs to be the most significant bit.
+template <typename T>
+struct nullable_tb {
+    T data;
+    bool valid;
+};
+// Lengths, offsets
+
+/// @brief Wrapper for nullable types
+template <typename T>
+struct nullable : public T {
+    bool valid = true;
+
+    template<typename... Args>
+    explicit nullable(bool _valid, Args &&... args) : T(std::forward<Args>(args)...), valid(_valid) {}
+
+    explicit nullable(bool _valid) : T(), valid(_valid) {}
+
+    nullable(bool _valid, nullable<T> _nullable) : T(_nullable.data, _nullable.dvalid, _nullable.last), valid(_valid) {}
+
+    template<typename IT>
+    nullable(nullable_tb<IT> _nullable_tb) : T(_nullable_tb.data), valid(_nullable_tb.valid) {}
+
+    template<typename IT>
+    nullable(nullable_tb<IT> _nullable_tb, bool _dvalid, bool _last) : T(_nullable_tb.data, _dvalid, _last),
+                                                                       valid(_nullable_tb.valid) {}
+
+    nullable() = default;
+
+};

--- a/integrations/vivado_hls/src/fletcher/components/operators.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#import "fletcher/components/operators/arith.h"
-#import "fletcher/components/operators/indecrement.h"
-#import "fletcher/components/operators/logical.h"
+#include "fletcher/components/operators/arith.h"
+#include "fletcher/components/operators/indecrement.h"
+#include "fletcher/components/operators/logical.h"
 
 //template <typename T>
 //f_packet<T> operator+(f_packet<T> &rhs) {

--- a/integrations/vivado_hls/src/fletcher/components/operators.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#import "fletcher/components/operators/arith.h"
+#import "fletcher/components/operators/indecrement.h"
+#import "fletcher/components/operators/logical.h"
+
+//template <typename T>
+//f_packet<T> operator+(f_packet<T> &rhs) {
+//    return f_packet<T>(+rhs.data, rhs.dvalid, rhs.last);
+//}
+//template <typename T>
+//f_packet<T> operator-(f_packet<T> &rhs) {
+//    return f_packet<T>(-rhs.data, rhs.dvalid, rhs.last);
+//}
+//
+//#pragma region Packet <-> Packet operators
+//template <typename T>
+//friend bool operator<(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return lhs.data < rhs.data;
+//}
+//template <typename T>
+//friend bool operator>(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return rhs < lhs;
+//}
+//template <typename T>
+//friend bool operator<=(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return !(rhs < lhs);
+//}
+//template <typename T>
+//friend bool operator>=(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return !(lhs < rhs);
+//}
+//
+//template <typename T>
+//friend f_packet<T> operator-(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return f_packet<T>(lhs.data - rhs.data, lhs.dvalid, lhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator*(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return f_packet<T>(lhs.data * rhs.data, lhs.dvalid, lhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator/(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return f_packet<T>(lhs.data / rhs.data, lhs.dvalid, lhs.last);
+//}
+//template <typename T>
+//friend bool operator==(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return lhs.data == rhs.data;
+//}
+//template <typename T>
+//friend bool operator!=(f_packet<T> &lhs, f_packet<T> &rhs) {
+//    return !(rhs == lhs);
+//}
+//
+//#pragma endregion
+//
+//#pragma region Packet <-> Base type operators
+//template <typename T>
+//friend bool operator<(f_packet<T> &lhs, T &rhs) {
+//    return lhs.data < rhs;
+//}
+//template <typename T>
+//friend bool operator>(f_packet<T> &lhs, T &rhs) {
+//    return rhs < lhs;
+//}
+//template <typename T>
+//friend bool operator<=(f_packet<T> &lhs, T &rhs) {
+//    return !(rhs < lhs);
+//}
+//template <typename T>
+//friend bool operator>=(f_packet<T> &lhs, T &rhs) {
+//    return !(lhs < rhs);
+//}
+//template <typename T>
+//friend f_packet<T> operator+(f_packet<T> &lhs, T &rhs) {
+//    return f_packet<T>(lhs.data + rhs, lhs.dvalid, lhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator-(f_packet<T> &lhs, T &rhs) {
+//    return f_packet<T>(lhs.data - rhs, lhs.dvalid, lhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator*(f_packet<T> &lhs, T &rhs) {
+//    return f_packet<T>(lhs.data * rhs, lhs.dvalid, lhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator/(f_packet<T> &lhs, T &rhs) {
+//    return f_packet<T>(lhs.data / rhs, lhs.dvalid, lhs.last);
+//}
+//template <typename T>
+//friend bool operator==(f_packet<T> &lhs, T &rhs) {
+//    return lhs.data == rhs;
+//}
+//template <typename T>
+//friend bool operator!=(f_packet<T> &lhs, T &rhs) {
+//    return !(rhs == lhs);
+//}
+//
+//#pragma endregion
+//
+//#pragma region Base type <-> Packet operators
+//template <typename T>
+//friend bool operator<(T &lhs, f_packet<T> &rhs) {
+//    return lhs < rhs.data;
+//}
+//template <typename T>
+//friend bool operator>(T &lhs, f_packet<T> &rhs) {
+//    return rhs < lhs;
+//}
+//template <typename T>
+//friend bool operator<=(T &lhs, f_packet<T> &rhs) {
+//    return !(rhs < lhs);
+//}
+//template <typename T>
+//friend bool operator>=(T &lhs, f_packet<T> &rhs) {
+//    return !(lhs < rhs);
+//}
+//template <typename T>
+//friend f_packet<T> operator+(T &lhs, f_packet<T> &rhs) {
+//    return f_packet<T>(lhs + rhs.data, rhs.dvalid, rhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator-(T &lhs, f_packet<T> &rhs) {
+//    return f_packet<T>(lhs - rhs.data, rhs.dvalid, rhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator*(T &lhs, f_packet<T> &rhs) {
+//    return f_packet<T>(lhs * rhs.data, rhs.dvalid, rhs.last);
+//}
+//template <typename T>
+//friend f_packet<T> operator/(T &lhs, f_packet<T> &rhs) {
+//    return f_packet<T>(lhs / rhs.data, rhs.dvalid, rhs.last);
+//}
+//template <typename T>
+//friend bool operator==(T &lhs, f_packet<T> &rhs) {
+//    return lhs == rhs.data;
+//}
+//template <typename T>
+//friend bool operator!=(T &lhs, f_packet<T> &rhs) {
+//    return !(rhs == lhs);
+//}
+//
+//#pragma endregion

--- a/integrations/vivado_hls/src/fletcher/components/operators/arith.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators/arith.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "../packet.h"
+#include "../nullable.h"
+
+#define OP +
+
+#include "base_arith.inc"
+#include "base_unary.inc"
+
+#define OP -
+
+#include "base_arith.inc"
+#include "base_unary.inc"
+
+#define OP *
+
+#include "base_arith.inc"
+
+#define OP /
+
+#include "base_arith.inc"
+
+#define OP %
+
+#include "base_arith.inc"
+
+#define OP &
+
+#include "base_arith.inc"
+
+#define OP |
+
+#include "base_arith.inc"
+
+#define OP ^
+
+#include "base_arith.inc"
+
+#define OP ~
+
+#include "base_unary.inc"
+
+#define OP <<
+
+#include "base_arith.inc"
+
+#define OP >>
+
+#include "base_arith.inc"

--- a/integrations/vivado_hls/src/fletcher/components/operators/arith.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators/arith.h
@@ -2,49 +2,49 @@
 
 #include "../packet.h"
 #include "../nullable.h"
-
 #define OP +
 
 #include "base_arith.inc"
 #include "base_unary.inc"
-
+#undef OP
 #define OP -
 
 #include "base_arith.inc"
 #include "base_unary.inc"
-
+#undef OP
 #define OP *
 
 #include "base_arith.inc"
-
+#undef OP
 #define OP /
 
 #include "base_arith.inc"
-
+#undef OP
 #define OP %
 
 #include "base_arith.inc"
-
+#undef OP
 #define OP &
 
 #include "base_arith.inc"
-
+#undef OP
 #define OP |
 
 #include "base_arith.inc"
-
+#undef OP
 #define OP ^
 
 #include "base_arith.inc"
-
+#undef OP
 #define OP ~
 
 #include "base_unary.inc"
-
+#undef OP
 #define OP <<
 
 #include "base_arith.inc"
-
+#undef OP
 #define OP >>
 
 #include "base_arith.inc"
+#undef OP

--- a/integrations/vivado_hls/src/fletcher/components/operators/base_arith.inc
+++ b/integrations/vivado_hls/src/fletcher/components/operators/base_arith.inc
@@ -1,0 +1,85 @@
+// Packet <-> Packet
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &lhs, f_packet<T> &rhs) {
+    return f_packet<T>(lhs.data OP rhs.data, lhs.dvalid, lhs.last);
+}
+
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &&lhs, f_packet<T> &&rhs) {
+    return lhs OP rhs;
+}
+
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &lhs, f_packet<T> &&rhs) {
+    return lhs OP rhs;
+}
+
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &&lhs, f_packet<T> &rhs) {
+    return lhs OP rhs;
+}
+
+// Packet <-> base types
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &lhs,T &rhs) {
+    return f_packet<T>(lhs.data OP rhs, lhs.dvalid, lhs.last);
+}
+
+template <typename T>
+f_packet<T> operator OP(T &lhs, f_packet<T> &rhs) {
+    return f_packet<T>(lhs OP rhs.data, rhs.dvalid, rhs.last);
+}
+
+// Packet <-> ctypes (like ints and other castable basics)
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &lhs, typename f_packet<T>::inner_type &&rhs) {
+    return f_packet<T>(lhs.data OP rhs, lhs.dvalid, lhs.last);
+}
+
+template <typename T>
+f_packet<T> operator OP(typename f_packet<T>::inner_type &&lhs, f_packet<T> &rhs) {
+    return f_packet<T>(lhs OP rhs.data, rhs.dvalid, rhs.last);
+}
+
+// Nullable <-> Nullable
+template <typename T>
+nullable<T> operator OP(nullable<T> &lhs, nullable<T> &rhs){
+    return nullable<T>(lhs.valid && rhs.valid, (static_cast<T&>(lhs) OP static_cast<T&>(rhs)));
+}
+
+template <typename T>
+nullable<T> operator OP(nullable<T> &&lhs, nullable<T> &&rhs){
+    return lhs OP rhs;
+}
+
+template <typename T>
+nullable<T> operator OP(nullable<T> &&lhs, nullable<T> &rhs){
+    return lhs OP rhs;
+}
+
+template <typename T>
+nullable<T> operator OP(nullable<T> &lhs, nullable<T> &&rhs){
+    return lhs OP rhs;
+}
+
+// Nullable <-> Packet
+template <typename T>
+nullable<T> operator OP(nullable<T> &lhs, T &&rhs){
+    return nullable<T>(lhs.valid, (static_cast<T&>(lhs) OP rhs));
+}
+
+template <typename T>
+nullable<T> operator OP(T &&lhs, nullable<T> &rhs){
+    return nullable<T>(rhs.valid, (lhs OP static_cast<T&>(rhs)));
+}
+
+// Nullable <-> Base types and ctypes
+template <typename T>
+nullable<T> operator OP(nullable<T> &lhs, typename T::inner_type rhs){
+    return nullable<T>(lhs.valid, (static_cast<T&>(lhs) OP rhs));
+}
+
+template <typename T>
+nullable<T> operator OP(typename T::inner_type lhs, nullable<T> &rhs){
+    return nullable<T>(rhs.valid, (lhs OP static_cast<T&>(rhs)));
+}

--- a/integrations/vivado_hls/src/fletcher/components/operators/base_arith.inc
+++ b/integrations/vivado_hls/src/fletcher/components/operators/base_arith.inc
@@ -76,10 +76,10 @@ nullable<T> operator OP(T &&lhs, nullable<T> &rhs){
 // Nullable <-> Base types and ctypes
 template <typename T>
 nullable<T> operator OP(nullable<T> &lhs, typename T::inner_type rhs){
-    return nullable<T>(lhs.valid, (static_cast<T&>(lhs) OP rhs));
+    return nullable<T>(lhs.valid, (static_cast<T&>(lhs) OP static_cast<typename T::inner_type>(rhs)));
 }
 
 template <typename T>
 nullable<T> operator OP(typename T::inner_type lhs, nullable<T> &rhs){
-    return nullable<T>(rhs.valid, (lhs OP static_cast<T&>(rhs)));
+    return nullable<T>(rhs.valid, (static_cast<typename T::inner_type>(lhs) OP static_cast<T&>(rhs)));
 }

--- a/integrations/vivado_hls/src/fletcher/components/operators/base_instance.inc
+++ b/integrations/vivado_hls/src/fletcher/components/operators/base_instance.inc
@@ -1,0 +1,30 @@
+
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &val) {
+    OP val.data;
+    return val;
+}
+
+template <typename T>
+nullable<T> operator OP(nullable<T> &val){
+    if(val.valid){
+        (OP val);
+    }
+    return val;
+}
+
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &val, int) {
+    f_packet<T> tmp(val);
+    OP val; // prefix-increment this instance
+    return tmp;   // return value before increment
+}
+
+template <typename T>
+nullable<T> operator OP(nullable<T> &val, int){
+    nullable<T> tmp(val);
+    if(val.valid){
+        (OP(static_cast<T&>(val)));
+    }
+    return tmp;
+}

--- a/integrations/vivado_hls/src/fletcher/components/operators/base_logical_derived.inc
+++ b/integrations/vivado_hls/src/fletcher/components/operators/base_logical_derived.inc
@@ -1,0 +1,17 @@
+template <typename T>
+bool operator!=(TYPEL lhs, TYPER rhs) {
+    return !(rhs == lhs);
+}
+
+template <typename T>
+bool operator>(TYPEL lhs, TYPER rhs) {
+    return rhs < lhs;
+}
+template <typename T>
+bool operator<=(TYPEL lhs, TYPER rhs) {
+    return !(rhs < lhs);
+}
+template <typename T>
+bool operator>=(TYPEL lhs, TYPER rhs) {
+    return !(lhs < rhs);
+}

--- a/integrations/vivado_hls/src/fletcher/components/operators/base_logical_main.inc
+++ b/integrations/vivado_hls/src/fletcher/components/operators/base_logical_main.inc
@@ -18,12 +18,12 @@ bool operator OP(f_packet<T> &lhs, f_packet<T> &&rhs) {
 
 // Packet <-> base types
 template <typename T>
-bool operator OP(T &&lhs, f_packet<T> &rhs) {
+bool operator OP(T &lhs, f_packet<T> &rhs) {
     return lhs OP rhs.data;
 }
 
 template <typename T>
-bool operator OP(f_packet<T> &lhs, T &&rhs) {
+bool operator OP(f_packet<T> &lhs, T &rhs) {
     return lhs.data OP rhs;
 }
 
@@ -82,8 +82,8 @@ bool operator OP(T &&lhs, nullable<T> &rhs) {
 // Nullable <-> Base types and ctypes
 template <typename T>
 bool operator OP(nullable<T> &lhs, typename T::inner_type rhs){
-    if (rhs.valid) {
-        return (static_cast<T&>(lhs) OP rhs);
+    if (lhs.valid) {
+        return (static_cast<T&>(lhs) OP static_cast<typename T::inner_type>(rhs));
     }
     return false;
 }
@@ -91,7 +91,7 @@ bool operator OP(nullable<T> &lhs, typename T::inner_type rhs){
 template <typename T>
 bool operator OP(typename T::inner_type lhs, nullable<T> &rhs){
     if (rhs.valid) {
-        return (lhs OP static_cast<T&>(rhs));
+        return (static_cast<typename T::inner_type>(lhs) OP static_cast<T&>(rhs));
     }
     return false;
 }

--- a/integrations/vivado_hls/src/fletcher/components/operators/base_logical_main.inc
+++ b/integrations/vivado_hls/src/fletcher/components/operators/base_logical_main.inc
@@ -1,0 +1,97 @@
+// Packet <-> Packet
+template <typename T>
+bool operator OP(f_packet<T> &lhs, f_packet<T> &rhs) {
+    return lhs.data OP rhs.data;
+}
+template <typename T>
+bool operator OP(f_packet<T> &&lhs, f_packet<T> &&rhs) {
+    return lhs OP rhs;
+}
+template <typename T>
+bool operator OP(f_packet<T> &&lhs, f_packet<T> &rhs) {
+    return lhs OP rhs;
+}
+template <typename T>
+bool operator OP(f_packet<T> &lhs, f_packet<T> &&rhs) {
+    return lhs OP rhs;
+}
+
+// Packet <-> base types
+template <typename T>
+bool operator OP(T &&lhs, f_packet<T> &rhs) {
+    return lhs OP rhs.data;
+}
+
+template <typename T>
+bool operator OP(f_packet<T> &lhs, T &&rhs) {
+    return lhs.data OP rhs;
+}
+
+// Packet <-> ctypes (like ints and other castable basics)
+template <typename T>
+bool operator OP(f_packet<T> &lhs, typename f_packet<T>::inner_type &&rhs) {
+    return lhs.data OP rhs;
+}
+
+template <typename T>
+bool operator OP(typename f_packet<T>::inner_type &&lhs, f_packet<T> &rhs) {
+    return lhs OP rhs.data;
+}
+
+// Nullable <-> Nullable
+template <typename T>
+bool operator OP(nullable<T> &lhs, nullable<T> &rhs) {
+    if (lhs.valid && rhs.valid) {
+        return (static_cast<T&>(lhs) OP static_cast<T&>(rhs));
+    }
+    return false;
+}
+
+template <typename T>
+bool operator OP(nullable<T> &&lhs, nullable<T> &&rhs) {
+    return lhs OP rhs;
+}
+
+template <typename T>
+bool operator OP(nullable<T> &&lhs, nullable<T> &rhs) {
+    return lhs OP rhs;
+}
+
+template <typename T>
+bool operator OP(nullable<T> &lhs, nullable<T> &&rhs) {
+    return lhs OP rhs;
+}
+
+// Nullable <-> Packet
+template <typename T>
+bool operator OP(nullable<T> &lhs, T &&rhs) {
+    if (lhs.valid) {
+        return (static_cast<T&>(lhs) OP rhs);
+    }
+    return false;
+}
+
+template <typename T>
+bool operator OP(T &&lhs, nullable<T> &rhs) {
+    if (rhs.valid) {
+        return (lhs OP static_cast<T>(rhs));
+    }
+    return false;
+}
+
+// Nullable <-> Base types and ctypes
+template <typename T>
+bool operator OP(nullable<T> &lhs, typename T::inner_type rhs){
+    if (rhs.valid) {
+        return (static_cast<T&>(lhs) OP rhs);
+    }
+    return false;
+}
+
+template <typename T>
+bool operator OP(typename T::inner_type lhs, nullable<T> &rhs){
+    if (rhs.valid) {
+        return (lhs OP static_cast<T&>(rhs));
+    }
+    return false;
+}

--- a/integrations/vivado_hls/src/fletcher/components/operators/base_unary.inc
+++ b/integrations/vivado_hls/src/fletcher/components/operators/base_unary.inc
@@ -1,0 +1,19 @@
+
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &rhs) {
+    return f_packet<T>(OP rhs.data, rhs.dvalid, rhs.last);
+}
+template <typename T>
+f_packet<T> operator OP(f_packet<T> &&rhs) {
+    return OP rhs;
+}
+
+template <typename T>
+nullable<T> operator OP(nullable<T> &rhs){
+    return nullable<T>(rhs.valid, (OP (static_cast<T&>(rhs))));
+}
+
+template <typename T>
+nullable<T> operator OP(nullable<T> &&rhs){
+    return OP rhs;
+}

--- a/integrations/vivado_hls/src/fletcher/components/operators/indecrement.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators/indecrement.h
@@ -2,11 +2,12 @@
 
 #include "../packet.h"
 #include "../nullable.h"
-
 #define OP ++
 
 #include "base_instance.inc"
-
+#undef OP
 #define OP --
 
 #include "base_instance.inc"
+
+#undef OP

--- a/integrations/vivado_hls/src/fletcher/components/operators/indecrement.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators/indecrement.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../packet.h"
+#include "../nullable.h"
+
+#define OP ++
+
+#include "base_instance.inc"
+
+#define OP --
+
+#include "base_instance.inc"

--- a/integrations/vivado_hls/src/fletcher/components/operators/logical.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators/logical.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "../packet.h"
+#include "../nullable.h"
+
+#define OP ==
+
+#include "base_logical_main.inc"
+
+#define OP <
+
+#include "base_logical_main.inc"
+
+#undef OP
+// Packet <-> Packet
+#define TYPEL f_packet<T> &
+#define TYPER TYPEL
+
+#include "base_logical_derived.inc"
+
+#define TYPEL f_packet<T> &&
+#define TYPER TYPEL
+
+#include "base_logical_derived.inc"
+
+#define TYPEL f_packet<T> &&
+#define TYPER f_packet<T> &
+
+#include "base_logical_derived.inc"
+
+#define TYPEL f_packet<T> &
+#define TYPER f_packet<T> &&
+
+#include "base_logical_derived.inc"
+
+// Packet <-> base types
+#define TYPEL f_packet<T> &
+#define TYPER T &
+
+#include "base_logical_derived.inc"
+
+#define TYPEL T &
+#define TYPER f_packet<T> &
+
+#include "base_logical_derived.inc"
+
+// Packet <-> ctypes (like ints and other castable basics)
+#define TYPEL f_packet<T> &
+#define TYPER typename f_packet<T>::inner_type &&
+
+#include "base_logical_derived.inc"
+
+#define TYPEL typename f_packet<T>::inner_type &&
+#define TYPER f_packet<T> &
+
+#include "base_logical_derived.inc"
+
+// Nullable <-> Nullable
+#define TYPEL nullable<T> &
+#define TYPER TYPEL
+
+#include "base_logical_derived.inc"
+
+#define TYPEL nullable<T> &&
+#define TYPER TYPEL
+
+#include "base_logical_derived.inc"
+
+#define TYPEL nullable<T> &&
+#define TYPER nullable<T> &
+
+#include "base_logical_derived.inc"
+
+#define TYPEL nullable<T> &
+#define TYPER nullable<T> &&
+
+#include "base_logical_derived.inc"
+
+// Nullable <-> Packet
+#define TYPEL nullable<T> &
+#define TYPER T &&
+
+#include "base_logical_derived.inc"
+
+#define TYPEL T &&
+#define TYPER nullable<T> &
+
+#include "base_logical_derived.inc"
+
+// Nullable <-> Base types and ctypes
+#define TYPEL nullable<T> &
+#define TYPER typename T::inner_type
+
+#include "base_logical_derived.inc"
+
+#define TYPEL typename T::inner_type
+#define TYPER nullable<T> &
+
+#include "base_logical_derived.inc"

--- a/integrations/vivado_hls/src/fletcher/components/operators/logical.h
+++ b/integrations/vivado_hls/src/fletcher/components/operators/logical.h
@@ -2,98 +2,132 @@
 
 #include "../packet.h"
 #include "../nullable.h"
-
 #define OP ==
 
 #include "base_logical_main.inc"
-
+#undef OP
 #define OP <
 
 #include "base_logical_main.inc"
 
 #undef OP
 // Packet <-> Packet
+#undef TYPEL
+#undef TYPER
 #define TYPEL f_packet<T> &
 #define TYPER TYPEL
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL f_packet<T> &&
 #define TYPER TYPEL
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL f_packet<T> &&
 #define TYPER f_packet<T> &
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL f_packet<T> &
 #define TYPER f_packet<T> &&
 
 #include "base_logical_derived.inc"
 
 // Packet <-> base types
+#undef TYPEL
+#undef TYPER
 #define TYPEL f_packet<T> &
 #define TYPER T &
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL T &
 #define TYPER f_packet<T> &
 
 #include "base_logical_derived.inc"
 
 // Packet <-> ctypes (like ints and other castable basics)
+#undef TYPEL
+#undef TYPER
 #define TYPEL f_packet<T> &
 #define TYPER typename f_packet<T>::inner_type &&
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL typename f_packet<T>::inner_type &&
 #define TYPER f_packet<T> &
 
 #include "base_logical_derived.inc"
 
 // Nullable <-> Nullable
+#undef TYPEL
+#undef TYPER
 #define TYPEL nullable<T> &
 #define TYPER TYPEL
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL nullable<T> &&
 #define TYPER TYPEL
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL nullable<T> &&
 #define TYPER nullable<T> &
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL nullable<T> &
 #define TYPER nullable<T> &&
 
 #include "base_logical_derived.inc"
 
 // Nullable <-> Packet
+#undef TYPEL
+#undef TYPER
 #define TYPEL nullable<T> &
 #define TYPER T &&
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL T &&
 #define TYPER nullable<T> &
 
 #include "base_logical_derived.inc"
 
 // Nullable <-> Base types and ctypes
+#undef TYPEL
+#undef TYPER
 #define TYPEL nullable<T> &
 #define TYPER typename T::inner_type
 
 #include "base_logical_derived.inc"
 
+#undef TYPEL
+#undef TYPER
 #define TYPEL typename T::inner_type
 #define TYPER nullable<T> &
 
 #include "base_logical_derived.inc"
+
+#undef TYPEL
+#undef TYPER

--- a/integrations/vivado_hls/src/fletcher/components/packet.h
+++ b/integrations/vivado_hls/src/fletcher/components/packet.h
@@ -8,7 +8,6 @@ struct f_packet : public f_packet_base
 {
     T data = 0;
     f_packet() = default;
-    virtual ~f_packet() = default;
     f_packet(T _data) : data(_data), f_packet_base() {}
     f_packet(T _data, bool dvalid, bool last) : data(_data), f_packet_base(dvalid, last) {}
 

--- a/integrations/vivado_hls/src/fletcher/components/packet.h
+++ b/integrations/vivado_hls/src/fletcher/components/packet.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#import "packet_base.h"
+#include "packet_base.h"
 
 /// @brief Packet template.
 template <typename T>

--- a/integrations/vivado_hls/src/fletcher/components/packet.h
+++ b/integrations/vivado_hls/src/fletcher/components/packet.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#import "packet_base.h"
+
+/// @brief Packet template.
+template <typename T>
+struct f_packet : public f_packet_base
+{
+    T data = 0;
+    f_packet() = default;
+    virtual ~f_packet() = default;
+    f_packet(T _data) : data(_data), f_packet_base() {}
+    f_packet(T _data, bool dvalid, bool last) : data(_data), f_packet_base(dvalid, last) {}
+
+    f_packet &operator=(const T val)
+    {
+        data = val;
+        return *this;
+    }
+
+    using inner_type = T;
+};

--- a/integrations/vivado_hls/src/fletcher/components/packet_base.h
+++ b/integrations/vivado_hls/src/fletcher/components/packet_base.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/// @brief Base packet containing count, dvalid and last.
+struct f_packet_base
+{
+    bool dvalid = true;
+    bool last = false;
+
+    f_packet_base() = default;
+
+    virtual ~f_packet_base() = default;
+
+    f_packet_base(bool _dvalid, bool _last) : dvalid(_dvalid), last(_last) {}
+};

--- a/integrations/vivado_hls/src/fletcher/components/packet_base.h
+++ b/integrations/vivado_hls/src/fletcher/components/packet_base.h
@@ -8,7 +8,5 @@ struct f_packet_base
 
     f_packet_base() = default;
 
-    virtual ~f_packet_base() = default;
-
     f_packet_base(bool _dvalid, bool _last) : dvalid(_dvalid), last(_last) {}
 };

--- a/integrations/vivado_hls/src/fletcher/components/types.h
+++ b/integrations/vivado_hls/src/fletcher/components/types.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <ap_int.h>
+#include <hls_half.h>
+#include "packet.h"
+
+/// @brief Packet for signed integers.
+template <unsigned int W>
+using f_spacket = f_packet<ap_int<W>>;
+
+/// @brief Packet for unsigned integers.
+template <unsigned int W>
+using f_upacket = f_packet<ap_uint<W>>;
+
+/// @brief Packet for half precision floats.
+using f_hpacket = f_packet<half>;
+
+/// @brief Packet for single precision floats.
+using f_fpacket = f_packet<float>;
+
+/// @brief Packet for double precision floats.
+using f_dpacket = f_packet<double>;
+
+/// @brief Packet for signed integers for multiple element per cycle.
+template <unsigned int W, unsigned int N>
+using f_mspacket = f_mpacket<ap_int<W>, N>;
+
+/// @brief Packet for unsigned integers for multiple element per cycle..
+template <unsigned int W, unsigned int N>
+using f_mupacket = f_mpacket<ap_uint<W>, N>;
+
+/// @brief Packet for half precision floats for multiple element per cycle.
+template <unsigned int N>
+using f_mhpacket = f_mpacket<half, N>;
+
+/// @brief Packet for single precision floats for multiple element per cycle.
+template <unsigned int N>
+using f_mfpacket = f_mpacket<float, N>;
+
+/// @brief Packet for double precision floats for multiple element per cycle..
+template <unsigned int N>
+using f_mdpacket = f_mpacket<double, N>;
+
+using f_base_length_type = ap_int<32>;
+using f_size = f_spacket<32>;
+
+// Arrow primitive types:
+using f_bool = f_upacket<1>;
+using f_int8 = f_spacket<8>;
+using f_int16 = f_spacket<16>;
+using f_int32 = f_spacket<32>;
+using f_int64 = f_spacket<64>;
+using f_uint8 = f_upacket<8>;
+using f_uint16 = f_upacket<16>;
+using f_uint32 = f_upacket<32>;
+using f_uint64 = f_upacket<64>;
+using f_float16 = f_hpacket;
+using f_float32 = f_fpacket;
+using f_float64 = f_dpacket;
+using f_date32 = f_upacket<32>;
+using f_date64 = f_upacket<64>;
+
+// Arrow primitive list types:
+template <unsigned int N>
+using f_mbool = f_mupacket<1, N>;
+template <unsigned int N>
+using f_mint8 = f_mspacket<8, N>;
+template <unsigned int N>
+using f_mint16 = f_mspacket<16, N>;
+template <unsigned int N>
+using f_mint32 = f_mspacket<32, N>;
+template <unsigned int N>
+using f_mint64 = f_mspacket<64, N>;
+template <unsigned int N>
+using f_muint8 = f_mupacket<8, N>;
+template <unsigned int N>
+using f_muint16 = f_mupacket<16, N>;
+template <unsigned int N>
+using f_muint32 = f_mupacket<32, N>;
+template <unsigned int N>
+using f_muint64 = f_mupacket<64, N>;
+template <unsigned int N>
+using f_mfloat16 = f_mhpacket<N>;
+template <unsigned int N>
+using f_mfloat32 = f_mfpacket<N>;
+template <unsigned int N>
+using f_mfloat64 = f_mdpacket<N>;
+template <unsigned int N>
+using f_mdate32 = f_mupacket<32, N>;
+template <unsigned int N>
+using f_mdate64 = f_mupacket<64, N>;
+
+//Strings
+using f_string = f_uint8 *;


### PR DESCRIPTION
This adds operators to the main packet struct. Record batch length is now unsigned. `nullable_tb` is an analog to nullable but for testbenches. `nullable` now has extra constructors to convert these.