### PR TITLE
Write ouput to configured output path in cerata

### DIFF
--- a/codegen/cerata/src/cerata/dot/dot.cc
+++ b/codegen/cerata/src/cerata/dot/dot.cc
@@ -28,12 +28,12 @@
 namespace cerata::dot {
 
 void DOTOutputGenerator::Generate() {
-  CreateDir(subdir());
+  CreateDir(root_dir_ + "/" + subdir());
   cerata::dot::Grapher dot;
   for (const auto &o : outputs_) {
     if (o.comp != nullptr) {
       CERATA_LOG(INFO, "DOT: Generating output for Graph: " + o.comp->name());
-      dot.GenFile(*o.comp, subdir() + "/" + o.comp->name() + ".dot");
+      dot.GenFile(*o.comp, root_dir_ + "/" + subdir() + "/" + o.comp->name() + ".dot");
     }
   }
 }

--- a/codegen/cerata/src/cerata/vhdl/vhdl.cc
+++ b/codegen/cerata/src/cerata/vhdl/vhdl.cc
@@ -33,7 +33,7 @@ namespace cerata::vhdl {
 
 void VHDLOutputGenerator::Generate() {
   // Make sure the subdirectory exists.
-  CreateDir(subdir());
+  CreateDir(root_dir_ + "/" + subdir());
   size_t num_graphs = 0;
   for (const auto &o : outputs_) {
     CERATA_LOG(INFO, "VHDL: Transforming Component " + o.comp->name() + " to VHDL-compatible version.");
@@ -42,7 +42,7 @@ void VHDLOutputGenerator::Generate() {
     CERATA_LOG(INFO, "VHDL: Generating sources for component " + o.comp->name());
     auto vhdl_source = vhdl_design.Generate();
     vhdl_source.ToString();
-    auto vhdl_path = subdir() + "/" + o.comp->name() + ".vhd";
+    auto vhdl_path = root_dir_ + "/" + subdir() + "/" + o.comp->name() + ".vhd";
 
     bool overwrite = false;
 

--- a/codegen/fletchgen/src/fletchgen/options.cc
+++ b/codegen/fletchgen/src/fletchgen/options.cc
@@ -45,8 +45,7 @@ bool Options::Parse(Options *options, int argc, char **argv) {
 
   // Output options:
   app.add_option("-o,--output_path", options->output_dir,
-                 "Path to the output directory to place the generated files. (Default: . )")
-      ->check(CLI::ExistingDirectory);
+                 "Path to the output directory to place the generated files. (Default: . )");
 
   app.add_option("-l,--language", options->languages,
                  "Select the output languages for your design. Each type of output will be stored in a "


### PR DESCRIPTION
Fixes #138.

We should use a path type for these functions. I'll create an issue to use the [filesystem](https://en.cppreference.com/w/cpp/filesystem) library, since we're already depending on C++17 for Cerata and Fletchgen.