### PR TITLE
Fix link to api docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,7 +1,3 @@
 # Summary
 
-- [Introduction](./introduction/introduction.md)
-
-- [Fletcher C++ run-time docs](http://abs-tudelft.github.io/fletcher/api/fletcher-cpp/html)
-- [Fletchgen docs](http://abs-tudelft.github.io/fletcher/api/fletchgen/html)
-- [Cerata API docs](http://abs-tudelft.github.io/fletcher/api/cerata/html)
+- [Fletcher](./introduction/fletcher.md)

--- a/docs/src/introduction/fletcher.md
+++ b/docs/src/introduction/fletcher.md
@@ -1,0 +1,5 @@
+# Fletcher
+
+- [Fletcher C++ run-time docs](http://abs-tudelft.github.io/fletcher/api/fletcher-cpp/html)
+- [Fletchgen docs](http://abs-tudelft.github.io/fletcher/api/fletchgen/html)
+- [Cerata API docs](http://abs-tudelft.github.io/fletcher/api/cerata/html)

--- a/docs/src/introduction/introduction.md
+++ b/docs/src/introduction/introduction.md
@@ -1,1 +1,0 @@
-# Introduction


### PR DESCRIPTION
Moved the links to the api docs so they show up when navigating to https://abs-tudelft.github.io/fletcher