### PR TITLE
Use filesystem library to deal with paths (#140)

### DIFF
--- a/codegen/cerata/CMakeLists.txt
+++ b/codegen/cerata/CMakeLists.txt
@@ -39,6 +39,8 @@ add_compile_unit(
     test/cerata/test_expressions.cc
     test/cerata/test_pool.cc
     test/cerata/test_types.cc
+  DEPS
+    stdc++fs
 )
 
 add_compile_unit(

--- a/codegen/cerata/src/cerata/utils.cc
+++ b/codegen/cerata/src/cerata/utils.cc
@@ -14,6 +14,7 @@
 
 #include "cerata/utils.h"
 
+#include <filesystem>
 #include <unordered_map>
 #include <string>
 
@@ -39,10 +40,13 @@ std::string ToString(const std::unordered_map<std::string, std::string> &meta) {
 }
 
 void CreateDir(const std::string &dir_name) {
-  // TODO(johanpel): Create directories in a portable manner, or just wait for <filesystem>
-  int ret = system(("mkdir -p " + dir_name).c_str());
-  if (ret == -1) {
-    CERATA_LOG(ERROR, "Could not create directory.");
+  // Check if the directory already exists, if not, create it.
+  if (!std::filesystem::exists(dir_name)) {
+    std::error_code err;
+    bool result = std::filesystem::create_directories(dir_name, err);
+    if (!result) {
+      CERATA_LOG(ERROR, "Could not create directories: " + dir_name + " Error message:" + err.message());
+    }
   }
 }
 


### PR DESCRIPTION
Solves #140, but is a bit tricky in terms of compiler support.

Clang 7 and GCC 8 support it but they're not that mainstream yet, requiring users to perform some additional steps on default systems like Ubuntu.

Also GCC requires some flags, but apparently Clang doesn't (at least not on my system).

This would require a bit more investigation to support it nicely.
