### PR TITLE
[Fletchgen] Prevent error message from showing up when using --help

### DIFF
--- a/codegen/fletchgen/src/fletchgen/fletchgen.cc
+++ b/codegen/fletchgen/src/fletchgen/fletchgen.cc
@@ -40,6 +40,12 @@ int main(int argc, char **argv) {
     return -1;
   }
 
+  // Quit the program early.
+  if (options->quit) {
+    fletcher::StopLogging();
+    return 0;
+  }
+
   // The resulting design.
   fletchgen::Design design;
   // Potential RecordBatch descriptors for simulation models.
@@ -117,6 +123,5 @@ int main(int argc, char **argv) {
 
   // Shut down logging
   fletcher::StopLogging();
-
   return 0;
 }

--- a/codegen/fletchgen/src/fletchgen/options.cc
+++ b/codegen/fletchgen/src/fletchgen/options.cc
@@ -22,7 +22,7 @@ namespace fletchgen {
 bool Options::Parse(Options *options, int argc, char **argv) {
   CLI::App app{"Fletchgen - The Fletcher Design Generator"};
 
-  app.get_formatter()->column_width(40);
+  app.get_formatter()->column_width(34);
 
   // Required options:
   app.add_option("-i,--input", options->schema_paths,
@@ -50,9 +50,9 @@ bool Options::Parse(Options *options, int argc, char **argv) {
   app.add_option("-l,--language", options->languages,
                  "Select the output languages for your design. Each type of output will be stored in a "
                  "seperate subfolder (e.g. <output folder>/vhdl/...). \n"
-                 "                                        Available languages:\n"
-                 "                                          vhdl: Export as VHDL files (default).\n"
-                 "                                          dot : Export as DOT graphs.");
+                 "Available languages:\n"
+                 "  vhdl: Export as VHDL files (default).\n"
+                 "  dot : Export as DOT graphs.");
 
   app.add_flag("-f,--force", options->overwrite,
                "Force overwriting source code files if they exists already. If this flag is *not* used and the source "
@@ -77,9 +77,12 @@ bool Options::Parse(Options *options, int argc, char **argv) {
 
   try {
     app.parse(argc, argv);
-  } catch (CLI::Error& e) {
-    FLETCHER_LOG(ERROR, e.what());
+  } catch (CLI::CallForHelp &e) {
     std::cout << app.help();
+    options->quit = true;
+    return true;
+  } catch (CLI::Error &e) {
+    FLETCHER_LOG(ERROR, e.get_name() + e.what());
     return false;
   }
 

--- a/codegen/fletchgen/src/fletchgen/options.h
+++ b/codegen/fletchgen/src/fletchgen/options.h
@@ -41,10 +41,10 @@ struct Options {
   std::vector<std::string> languages = {"vhdl", "dot"};
 
   /// SREC output path. This is the path where an SREC file based on input RecordBatches will be placed.
-  std::string srec_out_path = "\"\"";
+  std::string srec_out_path;
 
   /// SREC simulation output path, where the simulation should dump the memory contents of written RecordBatches.
-  std::string srec_sim_dump = "\"\"";
+  std::string srec_sim_dump;
 
   /// Name of the Kernel
   std::string kernel_name = "Kernel";
@@ -58,6 +58,9 @@ struct Options {
 
   /// Vivado HLS template
   bool vivado_hls = false;
+
+  /// Whether to quit the program without doing anything (useful for just showing help.)
+  bool quit = false;
 
   /// Make the output quiet. TODO(johanpel): not yet implemented.
   bool quiet = false;


### PR DESCRIPTION
CLI11 throws an exception when users supply --help that wasn't handled seperate from other exceptions. This fixes it, and exits Fletchgen on supplying --help.