### PR TITLE
[Common/C++] Use C++ code style for HexView

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
 
 project(fletcher)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+
 option(FLETCHER_BUILD_CERATA "Build cerata library" OFF)
 option(FLETCHER_BUILD_FLETCHGEN "Build fletchgen" OFF)
 option(FLETCHER_BUILD_COMMON "Build common library" OFF)

--- a/common/cpp/include/fletcher/hex-view.h
+++ b/common/cpp/include/fletcher/hex-view.h
@@ -16,42 +16,34 @@
 
 #include <string>
 #include <cstdint>
+#include <vector>
 
 namespace fletcher {
 
 /**
- * Structure for hex editor style command-line output
+ * Utility for hex editor style command-line output.
  */
 struct HexView {
   /**
    * @brief Construct a new HexView object
    * @param start Start address of the first byte.
-   * @param str Optional string to append any output to.
-   * @param row Starting row
-   * @param col Starting column
    * @param width Number of bytes per line
    */
-  explicit HexView(uint64_t start,
-                   std::string str = "",
-                   uint64_t row = 0,
-                   uint64_t col = 0,
-                   uint64_t width = 32);
+  explicit HexView(uint64_t start = 0, uint64_t width = 32);
 
-  /// @brief Return a hex editor style view of the memory that was added to this HexView, optionally with a \p header.
+  /// @brief Return a hex editor style view of the data that was added to this HexView, with an optional header.
   std::string ToString(bool header = true);
 
   /**
-   * @brief Add a memory region to be printed to the HexView
-   * @param ptr The memory
-   * @param size The size
+   * @brief Add data to be printed to the HexView.
+   * @param[in]  ptr  The start address of the data.
+   * @param[in] size  The size of the data.
    */
   void AddData(const uint8_t *ptr, size_t size);
 
-  std::string str;
-  uint64_t row;
-  uint64_t col;
-  uint64_t width;
-  uint64_t start;
+  uint64_t width = 32;
+  uint64_t start = 0;
+  std::vector<uint8_t> data;
 };
 
 }  // namespace fletcher

--- a/common/cpp/include/fletcher/hex-view.h
+++ b/common/cpp/include/fletcher/hex-view.h
@@ -41,8 +41,8 @@ struct HexView {
    */
   void AddData(const uint8_t *ptr, size_t size);
 
-  uint64_t width = 32;
-  uint64_t start = 0;
+  int64_t width = 32;
+  int64_t start = 0;
   std::vector<uint8_t> data;
 };
 

--- a/common/cpp/test/fletcher/test_common.cc
+++ b/common/cpp/test/fletcher/test_common.cc
@@ -12,25 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
-#include <string>
-#include <iostream>
 #include <gtest/gtest.h>
 #include <fletcher/common.h>
 #include <arrow/api.h>
 
-#include "test_schemas.h"
-#include "test_recordbatches.h"
+#include <vector>
+#include <string>
+#include <iostream>
+
+#include "fletcher/test_schemas.h"
+#include "fletcher/test_recordbatches.h"
 
 TEST(Common, AppendMetaRequired) {
   auto schema = fletcher::GetPrimReadSchema();
   ASSERT_NE(schema->metadata(), nullptr);
   std::unordered_map<std::string, std::string> map;
   schema->metadata()->ToUnorderedMap(&map);
-  ASSERT_TRUE(map.count("fletcher_name") > 0);
-  ASSERT_TRUE(map.count("fletcher_mode") > 0);
-  ASSERT_TRUE(map.at("fletcher_name") == "PrimRead");
-  ASSERT_TRUE(map.at("fletcher_mode") == "read");
+  ASSERT_GT(map.count("fletcher_name"), 0);
+  ASSERT_GT(map.count("fletcher_mode"), 0);
+  ASSERT_EQ(map.at("fletcher_name"), "PrimRead");
+  ASSERT_EQ(map.at("fletcher_mode"), "read");
 }
 
 TEST(Common, RecordBatchFileRoundTrip) {
@@ -40,4 +41,17 @@ TEST(Common, RecordBatchFileRoundTrip) {
   fletcher::ReadRecordBatchesFromFile("test-common.rb", &rbs_in);
   ASSERT_TRUE(rb_out->schema()->Equals(*rbs_in[0]->schema(), true));
   ASSERT_TRUE(rb_out->Equals(*rbs_in[0]));
+}
+
+TEST(Common, HexView) {
+  fletcher::HexView hv0(0, 8);
+  fletcher::HexView hv1(3, 16);
+  uint8_t data[] = {0x1, 0x2, 0x3, 0x4};
+  hv0.AddData(data, 4);
+  hv1.AddData(data, 4);
+  // Test with header
+  ASSERT_EQ(hv0.ToString(true), "                 00 01 02 03 04 05 06 07\n"
+                                "0000000000000000 01 02 03 04             ....    ");
+  // Test without header and offset
+  ASSERT_EQ(hv1.ToString(false), "0000000000000000          01 02 03 04                               ....         ");
 }


### PR DESCRIPTION
The HexView utility was a bit funky, so I've cleaned it up. It uses C++ constructs to generate the hex view string, rather than stuff that would require some preprocessor defines for different platforms because of inconsistency in implementation of some C functions that were used.