### PR TITLE
Remove malloc.h include from echo platform

### DIFF
--- a/platforms/echo/runtime/src/fletcher_echo.c
+++ b/platforms/echo/runtime/src/fletcher_echo.c
@@ -14,7 +14,6 @@
 
 #include <stdio.h>
 #include <memory.h>
-#include <malloc.h>
 #include <stdlib.h>
 
 #include "fletcher/fletcher.h"


### PR DESCRIPTION
This remove the `malloc.h` include from the echo platform since we're already including `stdlib.h`.