### PR TITLE
Remove deprecated attribute from runtime

### DIFF
--- a/runtime/cpp/include/fletcher/kernel.h
+++ b/runtime/cpp/include/fletcher/kernel.h
@@ -39,7 +39,7 @@ class Kernel {
    * @param[in] schema_set A vector of shared pointers to arrow::Schemas to check.
    * @return Returns true if the kernel implements an operation over a set of arrow::Schemas.
    */
-  [[deprecated]] bool ImplementsSchemaSet(const std::vector<std::shared_ptr<arrow::Schema>> &schema_set);
+  bool ImplementsSchemaSet(const std::vector<std::shared_ptr<arrow::Schema>> &schema_set);
 
   /**
    * @brief Reset the Kernel.


### PR DESCRIPTION
Looks like the function being deprecated was `ImplementsSchema`: https://github.com/abs-tudelft/fletcher/pull/142/files#diff-6dd2fd6b41501f23785a9adf44f73727L37

Since our api's are not stable yet, not explicitely deprecating this method is no issue.

I'm trying to build a platform runtime with gcc 4.8, and the `[[deprecated]]` attribute was added in 4.9: https://gcc.gnu.org/projects/cxx-status.html