### PR TITLE
Build Arrow 0.14 pyfletcher wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,8 @@ jobs:
 - job: pyfletcher
   pool:
     vmImage: ubuntu-latest
+  variables:
+    PKG_CONFIG_ALLOW_SYSTEM_LIBS: 1
   steps:
   - template: steps/install-python.yml@abs-tudelft
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ resources:
     name: abs-tudelft/azure-pipelines-templates
 
 variables:
-  arrowVersion: 0.14.1
+  arrowVersion: 0.14.0
 
 jobs:
 
@@ -82,7 +82,7 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - script: |
-      docker build --build-arg MANYLINUX=2010 -t pyfletcher-manylinux:2010 - < misc/Dockerfile.python &&
+      docker build --build-arg ARROW_VERSION=$(arrowVersion) --build-arg MANYLINUX=2010 -t pyfletcher-manylinux:2010 - < misc/Dockerfile.python &&
       docker run --rm -v $(Build.SourcesDirectory):/io pyfletcher-manylinux:2010
     displayName: Build pyfletcher manylinux wheels
   - template: steps/install-python.yml@abs-tudelft

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ resources:
     name: abs-tudelft/azure-pipelines-templates
 
 variables:
-  arrowVersion: 0.14.0
+  arrowVersion: 0.14.1
 
 jobs:
 
@@ -69,6 +69,30 @@ jobs:
       python3 setup.py bdist_wheel
     displayName: Wheel
     workingDirectory: $(Build.SourcesDirectory)/runtime/python
+  - script: |
+      pip3 install build/dist/pyfletcher*whl
+    workingDirectory: $(Build.SourcesDirectory)/runtime/python
+    displayName: Install wheel
+  - script: |
+      python3 -c "import pyfletcher"
+    displayName: Test import
+
+- job: manylinux
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - script: |
+      docker build --build-arg MANYLINUX=2010 -t pyfletcher-manylinux:2010 - < misc/Dockerfile.python &&
+      docker run --rm -v $(Build.SourcesDirectory):/io pyfletcher-manylinux:2010
+    displayName: Build pyfletcher manylinux wheels
+  - template: steps/install-python.yml@abs-tudelft
+  - script: |
+      pip3 install build/dist/pyfletcher*37*manylinux*
+    workingDirectory: $(Build.SourcesDirectory)/runtime/python
+    displayName: Test manylinux wheel
+  - script: |
+      python3 -c "import pyfletcher"
+    displayName: Test pyfletcher import
 
 - template: jobs/mdbook-gh-pages.yml@abs-tudelft
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ resources:
     name: abs-tudelft/azure-pipelines-templates
 
 variables:
-  arrowVersion: 0.14.0
+  arrowVersion: 0.14.1
 
 jobs:
 

--- a/misc/Dockerfile.python
+++ b/misc/Dockerfile.python
@@ -1,32 +1,25 @@
 ARG MANYLINUX=1
 FROM quay.io/pypa/manylinux${MANYLINUX}_x86_64 as pyfletcher-python-base
 
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.tar.gz | tar xz && \
-    for PIP in /opt/python/cp3{5,6,7}*/bin/pip3; do $PIP install auditwheel numpy pyarrow; done
-ENV PATH=/cmake-3.14.5-Linux-x86_64/bin:$PATH
+ARG CMAKE_VERSION=3.14.5
+ARG ARROW_VERSION=0.14.0
 
-RUN yum install -y boost-devel
-RUN curl -L https://github.com/apache/arrow/archive/apache-arrow-0.14.0.tar.gz | tar xz && \
-    cd arrow-apache-arrow-0.14.0 && \
+ENV PATH /opt/python/cp35-cp35m/bin:$PATH
+RUN yum install -y boost-devel && \
+    for PIP in /opt/python/cp3{5,6,7}*/bin/pip3; \
+      do $PIP install --upgrade \
+        auditwheel \
+        numpy \
+        pyarrow==${ARROW_VERSION} \
+    ;done && \
+    curl -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar xz -C /usr/local --strip-components=1 && \
+    curl -L https://github.com/apache/arrow/archive/apache-arrow-${ARROW_VERSION}.tar.gz | tar xz && \
+    cd arrow-apache-arrow-${ARROW_VERSION} && \
     cmake \
+      -DARROW_PYTHON=On \
       -DCMAKE_BUILD_TYPE=Release \
-      -DARROW_BUILD_TESTS=Off \
-      -DARROW_BOOST_HEADER_ONLY=On \
-      -DARROW_COMPUTE=Off \
-      -DARROW_CUDA=Off \
-      -DARROW_WITH_BROTLI=Off \
-      -DARROW_WITH_BZ2=Off \
-      -DARROW_WITH_LZ4=Off \
-      -DARROW_WITH_SNAPPY=Off \
-      -DARROW_WITH_ZLIB=Off \
-      -DARROW_WITH_ZSTD=Off \
-      -DARROW_ORC=Off \
-      -DARROW_TENSORFLOW=Off \
-      -DARROW_IPC=On \
-      -DARROW_BUILD_BENCHMARKS=Off \
-      -DARROW_DEPENDENCY_SOURCE=BUNDLED \
       cpp/ && \
-    make && \
+    make -j4 && \
     make install
 
 FROM pyfletcher-python-base

--- a/misc/Dockerfile.python
+++ b/misc/Dockerfile.python
@@ -2,7 +2,7 @@ ARG MANYLINUX=1
 FROM quay.io/pypa/manylinux${MANYLINUX}_x86_64 as pyfletcher-python-base
 
 ARG CMAKE_VERSION=3.14.5
-ARG ARROW_VERSION=0.14.0
+ARG ARROW_VERSION=0.14.1
 
 ENV PATH /opt/python/cp35-cp35m/bin:$PATH
 RUN yum install -y boost-devel && \

--- a/misc/manylinux_wheels.sh
+++ b/misc/manylinux_wheels.sh
@@ -10,6 +10,14 @@ cwd=`eval "cd $dir;pwd;cd - > /dev/null"`
 dir="$cwd/.."
 project=`eval "cd $dir;pwd;cd - > /dev/null"`
 
+# Remove old build files
+cd $project/runtime/python
+python3 setup.py clean
+
+# Remove eggs
+eggs="$project/runtime/python/.eggs"
+rm -rf $eggs
+
 # Make sure target dir is empty
 target="$project/runtime/python/build"
 rm -rf $target

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -125,7 +125,7 @@ setup(
                 include_dir
             ],
             libraries=pa.get_libraries() + ["fletcher"],
-            library_dirs=list(filter(None, pa.get_library_dirs())) + lib_dirs,
+            library_dirs=pa.get_library_dirs() + lib_dirs,
             runtime_library_dirs=pa.get_library_dirs() + lib_dirs,
             extra_compile_args=["-std=c++11", "-O3"],
             extra_link_args=["-std=c++11"]
@@ -134,12 +134,12 @@ setup(
     install_requires=[
         'numpy >= 1.14',
         'pandas',
-        'pyarrow == 0.14',
+        'pyarrow == 0.14.1',
     ],
     setup_requires=[
         'cython',
         'numpy',
-        'pyarrow == 0.14',
+        'pyarrow == 0.14.1',
         'plumbum',
         'pytest-runner'
     ],

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -64,8 +64,11 @@ class build(_build):
             except ImportError:
                 # TODO: download cmake 3.14 and extract in build dir
                 raise ImportError('CMake or make not found')
-            cmake['../../cpp/']['-DCMAKE_BUILD_TYPE=Release']['-DCMAKE_INSTALL_PREFIX={}'.format(output_dir)] & FG
-            make['-j'] & FG
+            cmake['../../cpp/']\
+                 ['-DCMAKE_BUILD_TYPE=Release']\
+                 ['-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0']\
+                 ['-DCMAKE_INSTALL_PREFIX={}'.format(output_dir)] & FG
+            make['-j4'] & FG
             make['install'] & FG
         _build.run(self)
 
@@ -113,12 +116,15 @@ setup(
             "pyfletcher.lib",
             ["pyfletcher/lib.pyx"],
             language="c++",
+            define_macros=[
+                ("_GLIBCXX_USE_CXX11_ABI", "0")
+            ],
             include_dirs=[
                 np.get_include(),
                 pa.get_include(),
                 include_dir
             ],
-            libraries= pa.get_libraries() + ["fletcher"],
+            libraries=pa.get_libraries() + ["fletcher"],
             library_dirs=list(filter(None, pa.get_library_dirs())) + lib_dirs,
             runtime_library_dirs=pa.get_library_dirs() + lib_dirs,
             extra_compile_args=["-std=c++11", "-O3"],
@@ -127,11 +133,11 @@ setup(
     ],
     install_requires=[
         'numpy >= 1.14',
+        'pandas',
         'pyarrow == 0.14',
-        'pandas'
     ],
     setup_requires=[
-        'cython >= 0.27',
+        'cython',
         'numpy',
         'pyarrow == 0.14',
         'plumbum',


### PR DESCRIPTION
This PR adds a job in the pipeline which builds and tests the manylinux wheels for pyfletcher. It also adds an install and import test step to the dev build job of pyfletcher.

Currently they both result in the following error:
```
ValueError: pyarrow.lib.DictionaryMemo size changed, may indicate binary incompatibility. Expected 184 from C header, got 160 from PyObject
```
which is fixed in https://github.com/apache/arrow/commit/690823ce5e863db89d9617818bfe7186d0544cca. 

This means we have to wait for the next release of pyarrow to be published on PyPi in order for this error to disappear. When that happens we can release 0.1 with working manylinux wheels for pyfletcher.