### PR TITLE
Clang-tidy passes and minor bug fixes

### DIFF
--- a/codegen/cerata/src/cerata/dot/dot.cc
+++ b/codegen/cerata/src/cerata/dot/dot.cc
@@ -15,7 +15,6 @@
 #include "cerata/dot/dot.h"
 
 #include <sstream>
-#include <fstream>
 
 #include "cerata/logging.h"
 #include "cerata/edge.h"

--- a/codegen/cerata/src/cerata/dot/dot.cc
+++ b/codegen/cerata/src/cerata/dot/dot.cc
@@ -63,7 +63,7 @@ std::string Grapher::GenEdges(const Graph &graph, int level) {
 
       // Draw edge
       ret << tab(level);
-      if (src->IsExpression() && config.nodes.expand.expression) {
+      if (src->IsExpression() && style.config.nodes.expand.expression) {
         auto srcname = ToHex(*src);
         ret << "\"" + srcname + "\"";
       } else {
@@ -108,25 +108,25 @@ std::string Grapher::GenEdges(const Graph &graph, int level) {
             + std::to_string((*dst->array())->IndexOf(*dst)) + "\"";
       }
 
-      if ((src->IsPort()) && config.nodes.ports) {
+      if ((src->IsPort()) && style.config.nodes.ports) {
         if (dst->IsSignal()) {
           // Port to signal
           sb << style.edge.port_to_sig;
         } else if (dst->IsPort()) {
           sb << style.edge.port_to_port;
         }
-      } else if (src->IsSignal() && config.nodes.signals) {
+      } else if (src->IsSignal() && style.config.nodes.signals) {
         if (dst->IsPort()) {
           // Signal to port
           sb << style.edge.sig_to_port;
         }
-      } else if (src->IsParameter() && config.nodes.parameters) {
+      } else if (src->IsParameter() && style.config.nodes.parameters) {
         sb << style.edge.param;
-      } else if (src->IsLiteral() && config.nodes.literals) {
+      } else if (src->IsLiteral() && style.config.nodes.literals) {
         sb << style.edge.lit;
-      } else if (src->IsExpression() && config.nodes.expressions) {
+      } else if (src->IsExpression() && style.config.nodes.expressions) {
         sb << style.edge.expr;
-        if (config.nodes.expand.expression) {
+        if (style.config.nodes.expand.expression) {
           sb << "lhead=\"cluster_" + NodeName(*src) + "\"";
         }
       } else {
@@ -245,7 +245,7 @@ std::string Style::GenDotRecordCell(const Type &t,
 
 std::string Grapher::GenNode(const Node &n, int level) {
   std::stringstream str;
-  if (n.IsExpression() && config.nodes.expand.expression) {
+  if (n.IsExpression() && style.config.nodes.expand.expression) {
     str << GenExpr(n);
   } else {
     // Indent
@@ -305,19 +305,19 @@ std::string Grapher::GenGraph(const Graph &graph, int level) {
   }
 
   // Nodes
-  if (config.nodes.expressions)
+  if (style.config.nodes.expressions)
     ret << GenNodes(graph, Node::NodeID::EXPRESSION, level + 1);
 
   // if (config.nodes.literals)
   //   ret << GenNodes(graph, Node::LITERAL, level + 1);
 
-  if (config.nodes.parameters)
+  if (style.config.nodes.parameters)
     ret << GenNodes(graph, Node::NodeID::PARAMETER, level + 1);
 
-  if (config.nodes.ports)
+  if (style.config.nodes.ports)
     ret << GenNodes(graph, Node::NodeID::PORT, level + 1);
 
-  if (config.nodes.signals)
+  if (style.config.nodes.signals)
     ret << GenNodes(graph, Node::NodeID::SIGNAL, level + 1, true);
 
   if (graph.IsComponent()) {

--- a/codegen/cerata/src/cerata/dot/dot.h
+++ b/codegen/cerata/src/cerata/dot/dot.h
@@ -32,8 +32,6 @@ namespace cerata::dot {
 struct Grapher {
   /// The style.
   Style style;
-  /// The configuration.
-  Config config;
   /// Edges that were already drawn.
   std::deque<Edge *> drawn_edges = {};
   Grapher() : Grapher(Style::normal()) {}

--- a/codegen/cerata/src/cerata/dot/style.cc
+++ b/codegen/cerata/src/cerata/dot/style.cc
@@ -14,10 +14,7 @@
 
 #include "cerata/dot/style.h"
 
-#include <memory>
-#include <deque>
 #include <string>
-#include <vector>
 #include <sstream>
 
 namespace cerata::dot {

--- a/codegen/cerata/src/cerata/edge.cc
+++ b/codegen/cerata/src/cerata/edge.cc
@@ -71,6 +71,22 @@ std::shared_ptr<Edge> Connect(Node *dst, Node *src) {
     }
   }
 
+  // If the source is a terminator
+  if (src->IsPort()) {
+    auto port = dynamic_cast<Port *>(src);
+    // Check if it has a parent
+    if (src->parent()) {
+      auto parent = *src->parent();
+      if (parent->IsInstance() && port->IsInput()) {
+        // If the parent is an instance, and the terminator node is an input, then we may not source from it.
+        throw std::logic_error("Cannot source from instance port " + src->ToString() + " of mode input.");
+      } else if (parent->IsComponent() && port->IsOutput()) {
+        // If the parent is a component, and the terminator node is an output, then we may not source from it.
+        throw std::logic_error("Cannot source from component port " + src->ToString() + " of mode output.");
+      }
+    }
+  }
+
   std::string edge_name = src->name() + "_to_" + dst->name();
   auto edge = Edge::Make(edge_name, dst, src);
   src->AddEdge(edge);

--- a/codegen/cerata/src/cerata/flattype.cc
+++ b/codegen/cerata/src/cerata/flattype.cc
@@ -19,7 +19,6 @@
 #include <memory>
 #include <deque>
 #include <string>
-#include <sstream>
 #include <iomanip>
 #include <iostream>
 

--- a/codegen/cerata/src/cerata/graph.cc
+++ b/codegen/cerata/src/cerata/graph.cc
@@ -20,7 +20,6 @@
 
 #include "cerata/utils.h"
 #include "cerata/node.h"
-#include "cerata/edge.h"
 #include "cerata/logging.h"
 #include "cerata/object.h"
 #include "cerata/pool.h"

--- a/codegen/cerata/src/cerata/logging.h
+++ b/codegen/cerata/src/cerata/logging.h
@@ -73,7 +73,7 @@ inline Logger &logger() {
 if (CERATA_LOG_##level == CERATA_LOG_FATAL) { \
   throw std::runtime_error(std::string(__FILE__) + ":" \
                          + std::to_string(__LINE__) + ":" \
-                         + std::string(__FUNCTION__) + ": " + msg); \
+                         + std::string(__FUNCTION__) + ": " + (msg)); \
 } else {  \
   logger().write(CERATA_LOG_##level, msg,  __FUNCTION__, __FILE__, __LINE__); \
 } \

--- a/codegen/cerata/src/cerata/object.cc
+++ b/codegen/cerata/src/cerata/object.cc
@@ -14,11 +14,8 @@
 
 #include "cerata/object.h"
 
-#include <string>
 #include <memory>
 
-#include "cerata/node.h"
-#include "cerata/node_array.h"
 #include "cerata/utils.h"
 
 namespace cerata {

--- a/codegen/cerata/src/cerata/pool.cc
+++ b/codegen/cerata/src/cerata/pool.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
 #include <memory>
 
 #include "cerata/pool.h"

--- a/codegen/cerata/src/cerata/transform.cc
+++ b/codegen/cerata/src/cerata/transform.cc
@@ -14,8 +14,6 @@
 
 #include "cerata/transform.h"
 
-#include <string>
-#include <memory>
 #include <deque>
 
 #include "cerata/graph.h"

--- a/codegen/cerata/src/cerata/type.cc
+++ b/codegen/cerata/src/cerata/type.cc
@@ -17,8 +17,6 @@
 #include <utility>
 #include <string>
 #include <iostream>
-#include <sstream>
-#include <iomanip>
 
 #include "cerata/utils.h"
 #include "cerata/node.h"

--- a/codegen/cerata/src/cerata/vhdl/architecture.cc
+++ b/codegen/cerata/src/cerata/vhdl/architecture.cc
@@ -14,8 +14,6 @@
 
 #include "cerata/vhdl/architecture.h"
 
-#include <memory>
-
 #include "cerata/graph.h"
 #include "cerata/vhdl/block.h"
 #include "cerata/vhdl/declaration.h"

--- a/codegen/cerata/src/cerata/vhdl/block.cc
+++ b/codegen/cerata/src/cerata/vhdl/block.cc
@@ -14,8 +14,6 @@
 
 #include "cerata/vhdl/block.h"
 
-#include <iostream>
-#include <sstream>
 #include <regex>
 #include <string>
 
@@ -43,7 +41,7 @@ Line &operator+=(Line &lhs, const std::string &str) { //NOLINT
 std::vector<size_t> Block::GetAlignments() const {
   std::vector<size_t> ret = {0};
   for (const auto &l : lines) {
-    for (uint p = 0; p < l.parts.size(); p++) {
+    for (size_t p = 0; p < l.parts.size(); p++) {
       if (p >= ret.size()) {
         ret.push_back(l.parts[p].length());
       } else if (l.parts[p].length() > ret[p]) {
@@ -140,7 +138,7 @@ Block &operator<<(Block &lhs, const std::string &rhs) {
 
 Block &operator<<=(Block &lhs, const std::string &rhs) { //NOLINT
   if (!lhs.lines.empty()) {
-    for (uint i = 0; i < lhs.lines.size() - 1; i++) {
+    for (size_t i = 0; i < lhs.lines.size() - 1; i++) {
       lhs.lines[i].parts.back().append(rhs);
     }
   }

--- a/codegen/cerata/src/cerata/vhdl/declaration.cc
+++ b/codegen/cerata/src/cerata/vhdl/declaration.cc
@@ -16,12 +16,8 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 #include <deque>
-#include <iostream>
-#include <algorithm>
 
-#include "cerata/edge.h"
 #include "cerata/node.h"
 #include "cerata/expression.h"
 #include "cerata/type.h"

--- a/codegen/cerata/src/cerata/vhdl/design.cc
+++ b/codegen/cerata/src/cerata/vhdl/design.cc
@@ -15,13 +15,11 @@
 #include "cerata/vhdl/design.h"
 
 #include <string>
-#include <memory>
 #include <unordered_map>
 #include <vector>
 #include <algorithm>
 
 #include "cerata/logging.h"
-#include "cerata/graph.h"
 #include "cerata/vhdl/resolve.h"
 #include "cerata/vhdl/declaration.h"
 #include "cerata/vhdl/architecture.h"

--- a/codegen/cerata/src/cerata/vhdl/identifier.cc
+++ b/codegen/cerata/src/cerata/vhdl/identifier.cc
@@ -16,7 +16,6 @@
 
 #include <utility>
 #include <string>
-#include <vector>
 #include <deque>
 
 namespace cerata::vhdl {
@@ -34,13 +33,13 @@ std::string Identifier::ToString() const {
   return ret;
 }
 
-Identifier::Identifier(std::initializer_list<std::string> parts, std::optional<char> sep) : separator_(std::move(sep)) {
+Identifier::Identifier(std::initializer_list<std::string> parts, std::optional<char> sep) : separator_(sep) {
   for (const auto &p : parts) {
     parts_.push_back(p);
   }
 }
 
-Identifier::Identifier(std::deque<std::string> parts, std::optional<char> sep) : separator_(std::move(sep)) {
+Identifier::Identifier(std::deque<std::string> parts, std::optional<char> sep) : separator_(sep) {
   parts_ = std::move(parts);
 }
 

--- a/codegen/cerata/src/cerata/vhdl/instantiation.cc
+++ b/codegen/cerata/src/cerata/vhdl/instantiation.cc
@@ -26,7 +26,6 @@
 
 #include "cerata/vhdl/instantiation.h"
 #include "cerata/vhdl/identifier.h"
-#include "cerata/vhdl/vhdl_types.h"
 #include "cerata/vhdl/vhdl.h"
 
 namespace cerata::vhdl {

--- a/codegen/cerata/src/cerata/vhdl/resolve.cc
+++ b/codegen/cerata/src/cerata/vhdl/resolve.cc
@@ -18,7 +18,6 @@
 #include <deque>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include "cerata/logging.h"
 #include "cerata/type.h"

--- a/codegen/cerata/src/cerata/vhdl/vhdl.cc
+++ b/codegen/cerata/src/cerata/vhdl/vhdl.cc
@@ -14,17 +14,11 @@
 
 #include "cerata/vhdl/vhdl.h"
 
-#include <algorithm>
 #include <vector>
 #include <string>
 #include <memory>
-#include <fstream>
 
 #include "cerata/logging.h"
-#include "cerata/edge.h"
-#include "cerata/node.h"
-#include "cerata/type.h"
-#include "cerata/graph.h"
 #include "cerata/utils.h"
 
 #include "cerata/vhdl/defaults.h"

--- a/codegen/cerata/src/cerata/vhdl/vhdl_types.cc
+++ b/codegen/cerata/src/cerata/vhdl/vhdl_types.cc
@@ -15,7 +15,6 @@
 #include "cerata/vhdl/vhdl_types.h"
 
 #include <memory>
-#include <algorithm>
 #include <deque>
 
 #include "cerata/vhdl/vhdl.h"

--- a/codegen/cerata/test/cerata/dot/test_graphs.cc
+++ b/codegen/cerata/test/cerata/dot/test_graphs.cc
@@ -35,4 +35,12 @@ TEST(Dot, Example) {
   dot.GenFile(*top, "Dot_Example.dot");
 }
 
+TEST(Dot, Expansion) {
+  default_component_pool()->Clear();
+  auto top = GetTypeExpansionComponent();
+  dot::Grapher dot;
+  dot.style.config = dot::Config::all();
+  dot.GenFile(*top, "Dot_Expansion.dot");
+}
+
 }  // namespace cerata

--- a/codegen/cerata/test/cerata/test_designs.h
+++ b/codegen/cerata/test/cerata/test_designs.h
@@ -22,6 +22,26 @@
 
 namespace cerata {
 
+std::shared_ptr<Component> GetTypeExpansionComponent() {
+  auto width = Parameter::Make("width", integer(), intl(8));
+  auto vec_type = Vector::Make("data", width);
+  auto rec_type = Record::Make("rec_type", {
+    RecField::Make("cerata", vec_type),
+    RecField::Make("is", vec_type),
+    RecField::Make("awesome", vec_type)
+  });
+  auto stream_type = Stream::Make("stream_type", rec_type);
+  auto data_in = Port::Make("data", stream_type, Port::Dir::IN);
+  auto data_out = Port::Make("data", stream_type, Port::Dir::OUT);
+  auto foo = Component::Make("foo", {width, data_in});
+  auto bar = Component::Make("bar", {width, data_out});
+  auto top = Component::Make("top");
+  auto foo_inst = top->AddInstanceOf(foo.get(), "foo");
+  auto bar_inst = top->AddInstanceOf(bar.get(), "bar");
+  Connect(foo_inst->port("data"), bar_inst->port("data"));
+  return top;
+}
+
 std::shared_ptr<Component> GetArrayToArrayComponent() {
   auto data = Vector::Make<8>();
 

--- a/codegen/cerata/test/cerata/test_expressions.cc
+++ b/codegen/cerata/test/cerata/test_expressions.cc
@@ -15,7 +15,6 @@
 #include <gmock/gmock.h>
 
 #include <string>
-#include <fstream>
 #include <memory>
 
 #include "cerata/api.h"

--- a/codegen/fletchgen/src/fletchgen/array.cc
+++ b/codegen/fletchgen/src/fletchgen/array.cc
@@ -448,7 +448,7 @@ std::shared_ptr<Type> GetStreamType(const arrow::Field &field, fletcher::Mode mo
 
       // Non-nested types
     default: {
-      type = GenTypeFrom(field.type());
+      type = ConvertFixedWidthType(field.type());
       break;
     }
   }
@@ -463,6 +463,9 @@ std::shared_ptr<Type> GetStreamType(const arrow::Field &field, fletcher::Mode mo
         RecField::Make("dvalid", dvalid()),
         RecField::Make("last", last()),
         RecField::Make("", type)});
+    if (field.nullable()) {
+      record->AddField(RecField::Make("validity", validity()));
+    }
     auto stream = Stream::Make(name, record);
     return stream;
   } else {

--- a/codegen/fletchgen/src/fletchgen/array.cc
+++ b/codegen/fletchgen/src/fletchgen/array.cc
@@ -175,7 +175,7 @@ static std::shared_ptr<Component> Array(Mode mode) {
   return ret;
 }
 
-std::unique_ptr<Instance> ArrayInstance(std::string name,
+std::unique_ptr<Instance> ArrayInstance(const std::string &name,
                                         fletcher::Mode mode,
                                         const std::shared_ptr<Node> &data_width,
                                         const std::shared_ptr<Node> &ctrl_width,

--- a/codegen/fletchgen/src/fletchgen/array.h
+++ b/codegen/fletchgen/src/fletchgen/array.h
@@ -105,7 +105,7 @@ std::shared_ptr<Type> GetStreamType(const arrow::Field &field, fletcher::Mode mo
  * @param tag_width   Command/unlock tag width parameter.
  * @return            A unique pointer holding the Array(Reader/Writer) instance.
  */
-std::unique_ptr<Instance> ArrayInstance(std::string name,
+std::unique_ptr<Instance> ArrayInstance(const std::string& name,
     fletcher::Mode mode = fletcher::Mode::READ,
                                         const std::shared_ptr<Node> &data_width = intl(1),
                                         const std::shared_ptr<Node> &ctrl_width = intl(1),

--- a/codegen/fletchgen/src/fletchgen/basic_types.cc
+++ b/codegen/fletchgen/src/fletchgen/basic_types.cc
@@ -40,16 +40,19 @@ using cerata::Literal;
   std::shared_ptr<Type> NAME() {                                        \
     static std::shared_ptr<Type> result = std::make_shared<Bit>(#NAME); \
     return result;                                                      \
-}
+  }
 
-/// Creates basic, multi-bit types similar to Arrow cpp/type.cc for convenience
-#define VEC_FACTORY(NAME, WIDTH)                                                     \
-  std::shared_ptr<Type> NAME() {                                                     \
-    static std::shared_ptr<Type> result = Vector::Make(#NAME, WIDTH); \
-    return result;                                                                   \
-}
+/// Creates basic, multi-bit types similar to Arrow cpp/type.cc for convenience, including their nullable versions.
+#define VEC_FACTORY(NAME, WIDTH)                                        \
+  std::shared_ptr<Type> NAME() {                                        \
+    static std::shared_ptr<Type> result = Vector::Make(#NAME, WIDTH);   \
+    return result;                                                      \
+  }
 
-BIT_FACTORY(null)
+// Validity bit
+BIT_FACTORY(validity)
+
+// Non-nullable fixed-width types.
 VEC_FACTORY(int8, 8)
 VEC_FACTORY(uint8, 8)
 VEC_FACTORY(int16, 16)
@@ -110,7 +113,7 @@ std::shared_ptr<Type> bus_cr() {
 }
 
 // Data channel
-std::shared_ptr<Type> data(const std::shared_ptr<Node>& width) {
+std::shared_ptr<Type> data(const std::shared_ptr<Node> &width) {
   std::shared_ptr<Type> result = Vector::Make("data", width);
   // Mark this type so later we can figure out that it was concatenated onto the data port of an ArrayReader/Writer.
   result->meta[metakeys::ARRAY_DATA] = "true";
@@ -118,14 +121,14 @@ std::shared_ptr<Type> data(const std::shared_ptr<Node>& width) {
 }
 
 // Length channel
-std::shared_ptr<Type> length(const std::shared_ptr<Node>& width) {
+std::shared_ptr<Type> length(const std::shared_ptr<Node> &width) {
   std::shared_ptr<Type> result = Vector::Make("length", width);
   // Mark this type so later we can figure out that it was concatenated onto the data port of an ArrayReader/Writer.
   result->meta[metakeys::ARRAY_DATA] = "true";
   return result;
 }
 
-std::shared_ptr<Type> count(const std::shared_ptr<Node>& width) {
+std::shared_ptr<Type> count(const std::shared_ptr<Node> &width) {
   std::shared_ptr<Type> result = Vector::Make("count", width);
   // Mark this type so later we can figure out that it was concatenated onto the data port of an ArrayReader/Writer.
   result->meta[metakeys::ARRAY_DATA] = "true";
@@ -142,7 +145,7 @@ std::shared_ptr<Type> last() {
   return result;
 }
 
-std::shared_ptr<Type> GenTypeFrom(const std::shared_ptr<arrow::DataType> &arrow_type) {
+std::shared_ptr<Type> ConvertFixedWidthType(const std::shared_ptr<arrow::DataType> &arrow_type) {
   // Only need to cover fixed-width data types in this function
   switch (arrow_type->id()) {
     case arrow::Type::UINT8: return uint8();

--- a/codegen/fletchgen/src/fletchgen/basic_types.cc
+++ b/codegen/fletchgen/src/fletchgen/basic_types.cc
@@ -18,7 +18,6 @@
 #include <fletcher/common.h>
 
 #include <memory>
-#include <cmath>
 
 namespace fletchgen {
 

--- a/codegen/fletchgen/src/fletchgen/basic_types.h
+++ b/codegen/fletchgen/src/fletchgen/basic_types.h
@@ -46,7 +46,7 @@ using cerata::TypeMapper;
 /// Generate declaration for basic, multi-bit types similar to Arrow cpp/type.cc for convenience
 #define VEC_DECL_FACTORY(NAME, WIDTH) std::shared_ptr<Type> NAME();
 
-BIT_DECL_FACTORY(null)
+BIT_DECL_FACTORY(validity)
 VEC_DECL_FACTORY(int8, 8)
 VEC_DECL_FACTORY(uint8, 8)
 VEC_DECL_FACTORY(int16, 16)
@@ -96,13 +96,13 @@ std::shared_ptr<Type> kernel_cr();
 std::shared_ptr<Type> bus_cr();
 
 /**
- * @brief Convert an arrow::DataType to a Fletcher Type.
+ * @brief Convert a fixed-width arrow::DataType to a fixed-width Fletcher Type.
  *
  * Does not take into consideration nesting.
  *
  * @param arrow_type    The arrow::DataType.
  * @return              The corresponding Type
  */
-std::shared_ptr<Type> GenTypeFrom(const std::shared_ptr<arrow::DataType> &arrow_type);
+std::shared_ptr<Type> ConvertFixedWidthType(const std::shared_ptr<arrow::DataType> &arrow_type);
 
 }  // namespace fletchgen

--- a/codegen/fletchgen/src/fletchgen/fletchgen.cc
+++ b/codegen/fletchgen/src/fletchgen/fletchgen.cc
@@ -20,7 +20,6 @@
 #include "fletchgen/options.h"
 #include "fletchgen/design.h"
 #include "fletchgen/utils.h"
-#include "fletchgen/hls/vivado.h"
 #include "fletchgen/srec/recordbatch.h"
 #include "fletchgen/top/sim.h"
 #include "fletchgen/top/axi.h"
@@ -89,7 +88,7 @@ int main(int argc, char **argv) {
     if (cerata::FileExists(sim_file_path) && !options->overwrite) {
       sim_file_path += 't';
     }
-    FLETCHER_LOG(INFO,"Saving simulation top-level design to: " + sim_file_path);
+    FLETCHER_LOG(INFO, "Saving simulation top-level design to: " + sim_file_path);
     sim_file = std::ofstream(sim_file_path);
     fletchgen::top::GenerateSimTop(*design.mantle,
                                    {&sim_file},
@@ -106,7 +105,7 @@ int main(int argc, char **argv) {
     if (cerata::FileExists(axi_file_path) && !options->overwrite) {
       axi_file_path += 't';
     }
-    FLETCHER_LOG(INFO,"Saving AXI top-level design to: " + axi_file_path);
+    FLETCHER_LOG(INFO, "Saving AXI top-level design to: " + axi_file_path);
     axi_file = std::ofstream(axi_file_path);
     fletchgen::top::GenerateAXITop(*design.mantle, {&axi_file});
     axi_file.close();

--- a/codegen/fletchgen/src/fletchgen/kernel.cc
+++ b/codegen/fletchgen/src/fletchgen/kernel.cc
@@ -14,15 +14,10 @@
 
 #include "fletchgen/kernel.h"
 
-#include <cerata/logging.h>
-#include <fletcher/common.h>
-
 #include <utility>
 #include <string>
 
 #include "fletchgen/basic_types.h"
-#include "fletchgen/schema.h"
-#include "fletchgen/utils.h"
 #include "fletchgen/recordbatch.h"
 #include "fletchgen/mmio.h"
 
@@ -51,7 +46,7 @@ Kernel::Kernel(std::string name, const std::deque<RecordBatch *> &recordbatches)
   }
 }
 
-std::shared_ptr<Kernel> Kernel::Make(std::string name, std::deque<RecordBatch *> recordbatches) {
+std::shared_ptr<Kernel> Kernel::Make(const std::string& name, const std::deque<RecordBatch *>& recordbatches) {
   return std::make_shared<Kernel>(name, recordbatches);
 }
 

--- a/codegen/fletchgen/src/fletchgen/kernel.h
+++ b/codegen/fletchgen/src/fletchgen/kernel.h
@@ -37,10 +37,7 @@ struct Kernel : Component {
   explicit Kernel(std::string name, const std::deque<RecordBatch *> &recordbatches = {});
 
   /// @brief Make a kernel component based on RecordBatch components. Returns a shared pointer to the new Kernel.
-  static std::shared_ptr<Kernel> Make(std::string name, std::deque<RecordBatch *> recordbatches = {});
-
-  /// The SchemaSet this Kernel is based on.
-  std::shared_ptr<SchemaSet> schema_set_;
+  static std::shared_ptr<Kernel> Make(const std::string& name, const std::deque<RecordBatch *>& recordbatches = {});
 };
 
 }  // namespace fletchgen

--- a/codegen/fletchgen/src/fletchgen/options.h
+++ b/codegen/fletchgen/src/fletchgen/options.h
@@ -79,13 +79,13 @@ struct Options {
   // Option checkers:
 
   /// @brief Return true if a design must be generated.
-  bool MustGenerateDesign() const;
+  [[nodiscard]] bool MustGenerateDesign() const;
   /// @brief Return true if an SREC file must be generated.
-  bool MustGenerateSREC() const;
+  [[nodiscard]] bool MustGenerateSREC() const;
   /// @brief Return true if the design must be outputted as VHDL.
-  bool MustGenerateVHDL() const;
+  [[nodiscard]] bool MustGenerateVHDL() const;
   /// @brief Return true if the design must be outputted as DOT.
-  bool MustGenerateDOT() const;
+  [[nodiscard]] bool MustGenerateDOT() const;
 
   /// @brief Load all specified RecordBatches
   void LoadRecordBatches();
@@ -93,7 +93,7 @@ struct Options {
   void LoadSchemas();
 
   /// @brief Return human-readable options.
-  std::string ToString() const;
+  [[nodiscard]] std::string ToString() const;
 };
 
 }  // namespace fletchgen

--- a/codegen/fletchgen/src/fletchgen/srec/recordbatch.cc
+++ b/codegen/fletchgen/src/fletchgen/srec/recordbatch.cc
@@ -15,14 +15,12 @@
 #include "fletchgen/srec/recordbatch.h"
 
 #include <arrow/api.h>
-#include <cerata/api.h>
 #include <fletcher/common.h>
 
 #include <deque>
 #include <memory>
 #include <ostream>
 
-#include "fletchgen/options.h"
 #include "fletchgen/srec/srec.h"
 
 namespace fletchgen::srec {

--- a/codegen/fletchgen/src/fletchgen/srec/srec.cc
+++ b/codegen/fletchgen/src/fletchgen/srec/srec.cc
@@ -16,8 +16,6 @@
 #include <fletcher/common.h>
 #include <sstream>
 #include <string>
-#include <iomanip>
-#include <cmath>
 #include <algorithm>
 
 #include "fletchgen/srec/srec.h"

--- a/codegen/fletchgen/src/fletchgen/utils.cc
+++ b/codegen/fletchgen/src/fletchgen/utils.cc
@@ -16,7 +16,6 @@
 
 #include <fletcher/common.h>
 #include <cerata/api.h>
-#include <cstdlib>  // system()
 
 namespace fletchgen {
 

--- a/codegen/fletchgen/test/fletchgen/test_mantle.cc
+++ b/codegen/fletchgen/test/fletchgen/test_mantle.cc
@@ -41,5 +41,9 @@ TEST(Mantle, StringRead) {
   TestReadMantle(fletcher::GetStringReadSchema());
 }
 
+TEST(Mantle, NullablePrim) {
+  TestReadMantle(fletcher::GetNullablePrimReadSchema());
+}
+
 
 }  // namespace fletchgen

--- a/codegen/fletchgen/test/fletchgen/test_recordbatch.cc
+++ b/codegen/fletchgen/test/fletchgen/test_recordbatch.cc
@@ -47,4 +47,8 @@ TEST(RecordBatch, StringRead) {
   TestRecordBatchReader(fletcher::GetStringReadSchema());
 }
 
+TEST(RecordBatch, NullablePrimRead) {
+  TestRecordBatchReader(fletcher::GetNullablePrimReadSchema());
+}
+
 }  // namespace fletchgen

--- a/common/cpp/include/fletcher/arrow-schema.h
+++ b/common/cpp/include/fletcher/arrow-schema.h
@@ -16,11 +16,11 @@
 
 #pragma once
 
+#include <arrow/api.h>
+
 #include <vector>
 #include <memory>
 #include <string>
-#include <utility>
-#include <arrow/api.h>
 
 #include "fletcher/arrow-utils.h"
 
@@ -31,6 +31,7 @@ class FieldAnalyzer : public arrow::TypeVisitor {
   FieldAnalyzer(FieldMetadata *field, std::vector<BufferMetadata> *buffers, std::string prefix = "")
       : field_out_(field), buffers_out_(buffers), buf_name_(std::move(prefix)) {}
   bool Analyze(const arrow::Field &field);
+
  protected:
   arrow::Status VisitField(const arrow::Field &field);
   arrow::Status VisitType(const arrow::DataType &type);
@@ -100,4 +101,4 @@ class SchemaAnalyzer : public arrow::TypeVisitor {
   RecordBatchDescription *out_{};
 };
 
-} // namespace fletcher
+}  // namespace fletcher

--- a/common/cpp/include/fletcher/arrow-utils.h
+++ b/common/cpp/include/fletcher/arrow-utils.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <arrow/api.h>
+
 #include <vector>
 #include <memory>
 #include <string>
-
-#include <arrow/buffer.h>
-#include <arrow/array.h>
+#include <utility>
 
 namespace fletcher {
 

--- a/common/cpp/src/fletcher/arrow-recordbatch.cc
+++ b/common/cpp/src/fletcher/arrow-recordbatch.cc
@@ -111,4 +111,5 @@ arrow::Status RecordBatchAnalyzer::Visit(const arrow::StructArray &array) {
   }
   return arrow::Status::OK();
 }
-} // namespace fletcher
+
+}  // namespace fletcher

--- a/common/cpp/src/fletcher/arrow-schema.cc
+++ b/common/cpp/src/fletcher/arrow-schema.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <arrow/api.h>
+
 #include <vector>
 #include <memory>
 #include <string>
-#include <utility>
-#include <arrow/api.h>
 
 #include "fletcher/logging.h"
 #include "fletcher/arrow-schema.h"
@@ -118,4 +118,4 @@ arrow::Status FieldAnalyzer::Visit(const arrow::StructType &type) {
   return arrow::Status::OK();
 }
 
-} // namespace fletcher
+}  // namespace fletcher

--- a/common/cpp/src/fletcher/hex-view.cc
+++ b/common/cpp/src/fletcher/hex-view.cc
@@ -41,7 +41,7 @@ std::string HexView::ToString(bool header) {
   // Create a header
   if (header) {
     ss << std::string(17, ' ');
-    for (unsigned int i = 0; i < width; i++) {
+    for (int64_t i = 0; i < width; i++) {
       ss << HEX2 << i;
       if (i != width - 1) {
         ss << " ";

--- a/common/cpp/test/fletcher/test_common.cc
+++ b/common/cpp/test/fletcher/test_common.cc
@@ -18,7 +18,6 @@
 
 #include <vector>
 #include <string>
-#include <iostream>
 
 #include "fletcher/test_schemas.h"
 #include "fletcher/test_recordbatches.h"

--- a/common/cpp/test/fletcher/test_schemas.h
+++ b/common/cpp/test/fletcher/test_schemas.h
@@ -19,6 +19,7 @@
 #include <arrow/api.h>
 #include <memory>
 #include <vector>
+#include <string>
 
 namespace fletcher {
 
@@ -35,6 +36,15 @@ inline std::shared_ptr<arrow::Schema> GetPrimReadSchema() {
   // Create a vector of fields that will form the schema.
   std::vector<std::shared_ptr<arrow::Field>> schema_fields = {
       arrow::field("number", arrow::int8(), false)
+  };
+  auto schema = std::make_shared<arrow::Schema>(schema_fields);
+  return AppendMetaRequired(*schema, "PrimRead", Mode::READ);
+}
+
+inline std::shared_ptr<arrow::Schema> GetNullablePrimReadSchema() {
+  // Create a vector of fields that will form the schema.
+  std::vector<std::shared_ptr<arrow::Field>> schema_fields = {
+      arrow::field("number", arrow::int8(), true)
   };
   auto schema = std::make_shared<arrow::Schema>(schema_fields);
   return AppendMetaRequired(*schema, "PrimRead", Mode::READ);


### PR DESCRIPTION
Mainly contains fixes for clang-tidy pass with check unused include option enabled.
Contains a few other bug fixes mainly related to dot output generation