### PR TITLE
Fix Fletchgen and Cerata build for Apple clang

### DIFF
--- a/codegen/cerata/src/cerata/vhdl/template.cc
+++ b/codegen/cerata/src/cerata/vhdl/template.cc
@@ -14,6 +14,7 @@
 
 #include "cerata/vhdl/template.h"
 
+#include <sstream>
 #include <iostream>
 #include "cerata/logging.h"
 

--- a/codegen/fletchgen/src/fletchgen/top/sim.cc
+++ b/codegen/fletchgen/src/fletchgen/top/sim.cc
@@ -45,7 +45,7 @@ static std::string GenMMIOWrite(uint32_t idx, uint32_t value, const std::string 
 static std::string CanonicalizePath(const std::string& path) {
   std::string result;
   if (!path.empty()) {
-    char *p = canonicalize_file_name(path.c_str());
+    char *p = realpath(path.c_str(), NULL);
     if (p == nullptr) {
       FLETCHER_LOG(FATAL, "Could not canonicalize path: " << path);
     }


### PR DESCRIPTION
macOS is not a supported platform, but it makes life easier for me when I can build these libs on macOS.