### PR TITLE
Add echo runtime to pyfletcher wheel

### DIFF
--- a/runtime/python/MANIFEST.in
+++ b/runtime/python/MANIFEST.in
@@ -1,6 +1,0 @@
-include LICENSE
-include README.md
-include HISTORY.md
-
-
-recursive-include pyfletcher *.py *.pxd *.pxi *.pyx *.h *.cpp

--- a/runtime/python/pyfletcher/error.pxi
+++ b/runtime/python/pyfletcher/error.pxi
@@ -17,11 +17,13 @@ import sys
 # Todo: Expand.
 cdef check_fletcher_status(Status status):
     """Handler for status messages returned by the CPP functions. To be expanded.
-    
+
     Args:
-        status: 
+        status:
 
     """
     if not status.ok():
         print("Fletcher error")
+
+    # TODO(mb): discuss this behavior
     status.ewf()

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -63,7 +63,8 @@ class build(_build):
             except ImportError:
                 # TODO: download cmake 3.14 and extract in build dir
                 raise ImportError('CMake or make not found')
-            cmake['../../cpp/']\
+            cmake['../../..']\
+                 ['-DFLETCHER_BUILD_ECHO=ON']\
                  ['-DCMAKE_BUILD_TYPE=Release']\
                  ['-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0']\
                  ['-DCMAKE_INSTALL_PREFIX={}'.format(output_dir)] & FG
@@ -84,7 +85,7 @@ class sdist(_sdist):
 class egg_info(_egg_info):
     def initialize_options(self):
         _egg_info.initialize_options(self)
-        self.egg_base = py_target_dir
+        self.egg_base = os.path.relpath(py_target_dir)
 
 setup(
     name="pyfletcher",
@@ -151,4 +152,7 @@ setup(
     },
     license='Apache License, Version 2.0',
     zip_safe = False,
+    data_files= [
+        ('lib', ['build/install/lib64/libfletcher_echo.so']),
+    ],
 )

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -21,7 +21,7 @@ from distutils.command.sdist import sdist as _sdist
 from setuptools.command.egg_info import egg_info as _egg_info
 from setuptools import setup, Extension, find_packages
 
-import os, platform, shutil
+import os, platform, shutil, glob
 import numpy as np
 import pyarrow as pa
 
@@ -153,6 +153,6 @@ setup(
     license='Apache License, Version 2.0',
     zip_safe = False,
     data_files= [
-        ('lib', ['build/install/lib64/libfletcher_echo.so']),
+        ('lib', glob.glob('build/install/lib*/libfletcher_echo.so')),
     ],
 )

--- a/runtime/python/tests/test_platform.py
+++ b/runtime/python/tests/test_platform.py
@@ -26,9 +26,8 @@ def test_platform():
     # Info
     print("Platform name: " + platform.name())
 
-    # Malloc/free
+    # Malloc
     address = platform.device_malloc(1024)
-    platform.device_free(address)
 
     # MMIO
     platform.write_mmio(0, 0)
@@ -41,11 +40,15 @@ def test_platform():
     host_bytearray = bytearray([1, 2, 3, 4, 5, 6, 7])
     host_nparray = np.array([1, 2, 3, 4, 5, 6, 7], dtype=np.uint8)
 
-    platform.copy_host_to_device(host_bytes, 0, size)
-    platform.copy_host_to_device(host_bytearray, 7, size)
-    platform.copy_host_to_device(host_nparray, 14, size)
+    platform.copy_host_to_device(host_bytes, address, size)
+    platform.copy_host_to_device(host_bytearray, address + 7, size)
+    platform.copy_host_to_device(host_nparray, address + 14, size)
 
-    buffer = platform.copy_device_to_host(0, 7)
+    buffer = platform.copy_device_to_host(address, 21)
+    assert list(buffer) == [1, 2, 3, 4, 5, 6, 7] * 3
+
+    # Free buffer
+    platform.device_free(address)
 
     platform.terminate()
 
@@ -90,3 +93,6 @@ def test_context():
 
     # Terminate
     platform.terminate()
+
+test_platform()
+# test_context()


### PR DESCRIPTION
Closes #183.

It uses `data_files` to install the echo platform, so there is no need to modify the platform generation code.