### PR TITLE
Add Python 3.8 support and manylinux2014 wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,8 +150,10 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - script: |
-      docker build --build-arg ARROW_VERSION=$(arrowVersion) --build-arg MANYLINUX=2010 --build-arg PACKAGE=$(source) -t $(package)-manylinux:2010 - < misc/Dockerfile.python &&
-      docker run --rm -v $(Build.SourcesDirectory):/io $(package)-manylinux:2010
+      for manylinux in 2010 2014; do
+        docker build --build-arg ARROW_VERSION=$(arrowVersion) --build-arg MANYLINUX=$manylinux --build-arg PACKAGE=$(source) -t $(package)-manylinux:$manylinux - < misc/Dockerfile.python &&
+        docker run --rm -v $(Build.SourcesDirectory):/io $(package)-manylinux:$manylinux
+      done
     displayName: Build manylinux wheels
   - template: steps/install-python.yml@abs-tudelft
   - script: |

--- a/misc/Dockerfile.python
+++ b/misc/Dockerfile.python
@@ -6,9 +6,10 @@ ARG ARROW_VERSION=0.15.1
 
 ENV PATH /opt/python/cp37-cp37m/bin:$PATH
 RUN yum install -y boost-devel && \
-    for PIP in /opt/python/cp3{5,6,7}*/bin/pip3; \
+    for PIP in /opt/python/cp3{5,6,7,8}*/bin/pip3; \
       do $PIP install --upgrade \
-        auditwheel \
+        pip \
+        auditwheel==3.0.0.0rc1 \
         numpy \
     ;done && \
     curl -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar xz -C /usr/local --strip-components=1 && \
@@ -23,11 +24,11 @@ RUN yum install -y boost-devel && \
     make install
 
 RUN cd arrow-apache-arrow-${ARROW_VERSION}/python && \
-    for PIP in /opt/python/cp3{5,6,7}*/bin/pip3; \
+    for PIP in /opt/python/cp3{5,6,7,8}*/bin/pip3; \
       do $PIP install --upgrade \
         Cython \
     ;done && \
-    for PYTHON in /opt/python/cp3{5,6,7}*/bin/python3; \
+    for PYTHON in /opt/python/cp3{5,6,7,8}*/bin/python3; \
       do $PYTHON setup.py build install \
     ;done
 
@@ -36,4 +37,4 @@ FROM fletcher-python-base
 ARG PACKAGE=
 
 WORKDIR /io/${PACKAGE}
-ENTRYPOINT ["bash", "-c", "for PYTHON in /opt/python/cp3{5,6,7}*/bin/python3; do $PYTHON setup.py bdist_wheel || exit 1; done; for WHL in build/dist/*.whl; do $PYTHON -m auditwheel show $WHL && $PYTHON -m auditwheel repair $WHL || exit 1; done; rm -rf build/python"]
+ENTRYPOINT ["bash", "-c", "for PYTHON in /opt/python/cp3{5,6,7,8}*/bin/python3; do $PYTHON setup.py bdist_wheel || exit 1; done; for WHL in build/dist/*.whl; do $PYTHON -m auditwheel show $WHL && $PYTHON -m auditwheel repair $WHL || exit 1; done; rm -rf build/python"]

--- a/misc/manylinux_wheels.sh
+++ b/misc/manylinux_wheels.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script builds manylinux{1, 2010} wheels in runtime/python/build/dist
+# This script builds manylinux{2010, 2014} wheels in runtime/python/build/dist
 # Usage: ./manylinux_wheels.sh
 
 set -e -x
@@ -19,7 +19,11 @@ for package in runtime/python codegen/python; do
   eggs="$project/$package/.eggs"
   rm -rf $eggs
 
-  docker build --build-arg MANYLINUX=2010 --build-arg PACKAGE=$package -t manylinux-$package:2010 -f "$cwd/Dockerfile.python" "$cwd"
-  docker run --rm -v "$project":/io manylinux-$package:2010
+  for manylinux in 2010 2014; do
+    # Build images and eggs in container
+    docker build --build-arg MANYLINUX=$manylinux --build-arg PACKAGE=$package -t manylinux-$package:$manylinux -f "$cwd/Dockerfile.python" "$cwd"
+    docker run --rm -v "$project":/io manylinux-$package:$manylinux
+  done
+
 done
 


### PR DESCRIPTION
[Python 3.8](https://www.python.org/downloads/release/python-380/) was released on Oct 14, 2019. This update adds wheels for this new version and also adds wheels for the updated [manylinux2014](https://www.python.org/dev/peps/pep-0599/) standard.

This results in longer runtimes for CI, so maybe I want to split these jobs or reduce the number of wheels. I also want to see if we can add builds for `ppc64le` wheels.