### PR TITLE
Bump Arrow to 0.17.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ resources:
     name: abs-tudelft/azure-pipelines-templates
 
 variables:
-  arrowVersion: 0.17.0
+  arrowVersion: 0.17.1
 
 jobs:
 

--- a/codegen/cpp/fletchgen/README.md
+++ b/codegen/cpp/fletchgen/README.md
@@ -34,7 +34,7 @@ It currently supports only two top-level platforms.
 
 # Prerequisites
 * [C++17 compliant compiler](https://clang.llvm.org/)
-* [Apache Arrow 0.17.0+](https://github.com/apache/arrow)
+* [Apache Arrow 0.17+](https://github.com/apache/arrow)
 * [CMake 3.14+](https://cmake.org/)
 
 # Build & install

--- a/codegen/python/setup.py
+++ b/codegen/python/setup.py
@@ -119,12 +119,12 @@ setup(
     install_requires=[
         'numpy >= 1.14',
         'pandas',
-        'pyarrow == 0.17.0',
+        'pyarrow == 0.17.1',
     ],
     setup_requires=[
         'cython',
         'numpy',
-        'pyarrow == 0.17.0',
+        'pyarrow == 0.17.1',
         'plumbum'
     ],
     classifiers=[

--- a/examples/sum/README.md
+++ b/examples/sum/README.md
@@ -8,7 +8,7 @@ open-source tools.
 ### For hardware generation (step 1 - 3):
 The examples in this part of the tutorial are written in Python, so you'll need
 * Install [Python 3.6+](https://www.python.org/).
-* Install [PyArrow 0.17.0+](https://arrow.apache.org/docs/python/).
+* Install [PyArrow 0.17+](https://arrow.apache.org/docs/python/).
 
 Furthermore you'll need to build and install Fletchgen - the Fletcher design
 generator tool.

--- a/misc/Dockerfile.python
+++ b/misc/Dockerfile.python
@@ -1,7 +1,7 @@
-ARG MANYLINUX=1
+ARG MANYLINUX=2014
 FROM quay.io/pypa/manylinux${MANYLINUX}_x86_64:latest as fletcher-python-base
 
-ARG CMAKE_VERSION=3.16.6
+ARG CMAKE_VERSION=3.17.2
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar xz -C /usr/local --strip-components=1
 
 ARG ARROW_VERSION=0.17.1
@@ -35,4 +35,4 @@ FROM fletcher-python-base
 ARG PACKAGE=
 
 WORKDIR /io/${PACKAGE}
-ENTRYPOINT ["bash", "-c", "for PYTHON in /opt/python/cp3{6,7,8}*/bin/python3; do $PYTHON setup.py bdist_wheel || exit 1; done; for WHL in build/dist/*.whl; do $PYTHON -m auditwheel show $WHL && $PYTHON -m auditwheel repair $WHL || exit 1; done; rm -rf build/python"]
+ENTRYPOINT ["bash", "-c", "for PYTHON in /opt/python/cp3{6,7,8}*/bin/python3; do $PYTHON setup.py bdist_wheel || exit 1; done; for WHL in build/dist/*.whl; do $PYTHON -m auditwheel show $WHL && $PYTHON -m auditwheel repair $WHL || exit 1; done; rm -rf build/python build/CMakeCache.txt"]

--- a/misc/Dockerfile.python
+++ b/misc/Dockerfile.python
@@ -4,7 +4,7 @@ FROM quay.io/pypa/manylinux${MANYLINUX}_x86_64:latest as fletcher-python-base
 ARG CMAKE_VERSION=3.16.6
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar xz -C /usr/local --strip-components=1
 
-ARG ARROW_VERSION=0.17.0
+ARG ARROW_VERSION=0.17.1
 RUN curl -L https://github.com/apache/arrow/archive/apache-arrow-${ARROW_VERSION}.tar.gz | tar xz
 
 WORKDIR arrow-apache-arrow-${ARROW_VERSION}

--- a/misc/loc.sh
+++ b/misc/loc.sh
@@ -1,6 +1,0 @@
-# Counts lines of code of the core components of Fletcher
-
-cloc 	--exclude-dir=platforms,CLI,examples \
-	../../.
-
-

--- a/runtime/cpp/README.md
+++ b/runtime/cpp/README.md
@@ -6,7 +6,7 @@ The Fletcher C++ Run-time Library enables support for Fletcher-based accelerated
 
 To build this library, the following packages are required to be installed:
 
-* [Apache Arrow 0.17.0+ C++ run-time and development headers](https://arrow.apache.org/install)
+* [Apache Arrow 0.17+ C++ run-time and development headers](https://arrow.apache.org/install)
 
 # Build & install
 

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -124,12 +124,12 @@ setup(
     install_requires=[
         'numpy >= 1.14',
         'pandas',
-        'pyarrow == 0.17.0',
+        'pyarrow == 0.17.1',
     ],
     setup_requires=[
         'cython',
         'numpy',
-        'pyarrow == 0.17.0',
+        'pyarrow == 0.17.1',
         'plumbum',
         'pytest-runner'
     ],


### PR DESCRIPTION
[Release notes](https://arrow.apache.org/release/0.17.1.html)