### PR TITLE
[C++] Do not start with sleep when polling for completion.

### DIFF
--- a/examples/stringwrite/software/cpp/src/stringwrite.cpp
+++ b/examples/stringwrite/software/cpp/src/stringwrite.cpp
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
 
   t.start();
   kernel.Start();
-  kernel.WaitForFinish(100);
+  kernel.PollUntilDoneInterval(100);
   t.stop();
   std::cout << "FPGA Process stream              : " << t.seconds() << std::endl;
 

--- a/examples/sum/software/cpp/src/sum.cpp
+++ b/examples/sum/software/cpp/src/sum.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
   status = platform->Init();
 
   if (!status.ok()) {
-    std::cerr << "Could not create Fletcher platform." << std::endl;
+    std::cerr << "Could not initialize Fletcher platform." << std::endl;
     return -1;
   }
 
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
   }
 
   // Wait for the kernel to finish.
-  status = kernel.WaitForFinish();
+  status = kernel.PollUntilDone();
 
   if (!status.ok()) {
     std::cerr << "Something went wrong waiting for the kernel to finish." << std::endl;

--- a/examples/sum/software/cpp/src/sum_tiny.cpp
+++ b/examples/sum/software/cpp/src/sum_tiny.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
 
   Kernel kernel(context);                       // Set up an interface to the Kernel, supplying the Context.
   kernel.Start();                               // Start the kernel.
-  kernel.WaitForFinish();                       // Wait for the kernel to finish.
+  kernel.PollUntilDone();                       // Wait for the kernel to finish.
 
   kernel.GetReturn(&result);                    // Obtain the result.
   std::cout << "Sum: " << result << std::endl;  // Print the result.

--- a/examples/sum/software/python/sum.py
+++ b/examples/sum/software/python/sum.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     kernel = pf.Kernel(context)                      # Set up an interface to the Kernel, supplying the Context.
     kernel.start()                                   # Start the kernel.
-    kernel.wait_for_finish()                         # Wait for the kernel to finish.
+    kernel.poll_until_done()                         # Wait for the kernel to finish.
 
     result = kernel.get_return(np.dtype(np.uint32))  # Obtain the result.
     print("Sum: " + str(result))                     # Print the result.

--- a/platforms/echo/runtime/src/fletcher_echo.c
+++ b/platforms/echo/runtime/src/fletcher_echo.c
@@ -49,18 +49,23 @@ fstatus_t platformInit(void *arg) {
 }
 
 fstatus_t platformWriteMMIO(uint64_t offset, uint32_t value) {
-  echo_print("[ECHO] Writing MMIO register.       %04lu <= 0x%08X\n", offset, value);
+  echo_print("[ECHO] Wrote MMIO register.       %04lu <= 0x%08X\n", offset, value);
   return FLETCHER_STATUS_OK;
 }
 
 fstatus_t platformReadMMIO(uint64_t offset, uint32_t *value) {
-  *value = 0xDEADBEEF;
-  echo_print("[ECHO] Reading MMIO register.       %04lu => 0x%08X\n", offset, *value);
+  char buffer[256];
+  unsigned long val = 0;
+  printf("[ECHO] Enter the value for MMIO register at offset %lu: 0x", offset);
+  fgets(buffer, 256, stdin);
+  val = strtoul(buffer, NULL, 16);
+  *value = val;
+  echo_print("[ECHO] Read MMIO register.       %04lu => 0x%08X\n", offset, *value);
   return FLETCHER_STATUS_OK;
 }
 
 fstatus_t platformCopyHostToDevice(const uint8_t *host_source, da_t device_destination, int64_t size) {
-  memcpy((void*)device_destination, host_source, size);
+  memcpy((void *) device_destination, host_source, size);
   echo_print("[ECHO] Copied from host to device.  [host] 0x%016lX --> [dev] 0x%016lX (%ld bytes)\n",
              (uint64_t) host_source,
              device_destination,
@@ -69,7 +74,7 @@ fstatus_t platformCopyHostToDevice(const uint8_t *host_source, da_t device_desti
 }
 
 fstatus_t platformCopyDeviceToHost(da_t device_source, uint8_t *host_destination, int64_t size) {
-  memcpy(host_destination, (void*)device_source, size);
+  memcpy(host_destination, (void *) device_source, size);
   echo_print("[ECHO] Copied from device to host.  [dev] 0x%016lX --> [host] 0x%016lX (%ld bytes)\n",
              device_source,
              (uint64_t) host_destination,
@@ -84,8 +89,10 @@ fstatus_t platformTerminate(void *arg) {
 
 fstatus_t platformDeviceMalloc(da_t *device_address, int64_t size) {
   // Aligned allocate some memory.
-  posix_memalign((void**)device_address, FLETCHER_ECHO_ALIGNMENT, (size_t) size);
-  echo_print("[ECHO] Allocating device memory.    [device] 0x%016lX (%10lu bytes).\n", (uint64_t)*device_address, size);
+  posix_memalign((void **) device_address, FLETCHER_ECHO_ALIGNMENT, (size_t) size);
+  echo_print("[ECHO] Allocating \"device\" memory.    [device] 0x%016lX (%10lu bytes).\n",
+             (uint64_t) *device_address,
+             size);
   return FLETCHER_STATUS_OK;
 }
 

--- a/platforms/echo/runtime/src/fletcher_echo.h
+++ b/platforms/echo/runtime/src/fletcher_echo.h
@@ -34,10 +34,10 @@ fstatus_t platformGetName(char *name, size_t size);
 /// arguments.
 fstatus_t platformInit(void *arg);
 
-/// @brief Write \p value to MMIO register \p offset
+/// @brief Write \p value to MMIO register \p offset.
 fstatus_t platformWriteMMIO(uint64_t offset, uint32_t value);
 
-/// @brief Read MMIO register \p offset into \p value
+/// @brief Read MMIO register \p offset into \p value. For the Echo platform, the value is taken from stdin.
 fstatus_t platformReadMMIO(uint64_t offset, uint32_t *value);
 
 /// @brief Copy \p size bytes from host address \p host_source to device address \p device_destination.
@@ -46,7 +46,12 @@ fstatus_t platformCopyHostToDevice(const uint8_t *host_source, da_t device_desti
 /// @brief Copy \p size bytes from device address \p device_source to host address \p host_destination.
 fstatus_t platformCopyDeviceToHost(da_t device_source, uint8_t *host_destination, int64_t size);
 
-/// @brief Allocate \p size bytes on the device.
+/**
+ * @brief Allocate \p size bytes on the device.
+ *
+ * For the Echo platform, this just allocates host memory.
+ * The host memory address will be stored at device_address.
+ */
 fstatus_t platformDeviceMalloc(da_t *device_address, int64_t size);
 
 /// @brief Free the memory allocated at \p device_address.

--- a/runtime/cpp/include/fletcher/kernel.h
+++ b/runtime/cpp/include/fletcher/kernel.h
@@ -85,17 +85,19 @@ class Kernel {
   Status GetReturn(uint32_t *ret0, uint32_t *ret1 = nullptr);
 
   /**
-   * @brief Wait for the kernel to finish (blocking).
+   * @brief Poll (blocking) the done flag of the status register for assertion with an interval.
    * @param[in] poll_interval_usec The interval at which to poll the Kernel.
    * @return Status::OK() when the kernel is finished, otherwise a descriptive error status.
    */
-  Status WaitForFinish(unsigned int poll_interval_usec);
+  Status PollUntilDoneInterval(unsigned int poll_interval_usec);
 
   /**
-   * @brief Wait for the kernel to finish (blocking). Polls at maximum speed.
+   * @brief Poll the done flag of the status register for assertion (blocking). Polls at maximum speed.
    * @return Status::OK() when the kernel is finished, otherwise a descriptive error status.
+   *
+   * Polling at maximum speed can cause a significant amount of traffic on the accelerator interface; use with care.
    */
-  Status WaitForFinish();
+  Status PollUntilDone();
 
   /// @brief Return the context of this Kernel.
   std::shared_ptr<Context> context();

--- a/runtime/cpp/src/fletcher/kernel.cc
+++ b/runtime/cpp/src/fletcher/kernel.cc
@@ -58,7 +58,7 @@ Status Kernel::SetRange(size_t recordbatch_index, int32_t first, int32_t last) {
   return Status::OK();
 }
 
-Status Kernel::SetArguments(const std::vector<uint32_t>& arguments) {
+Status Kernel::SetArguments(const std::vector<uint32_t> &arguments) {
   for (int i = 0; (size_t) i < arguments.size(); i++) {
     context_->platform()->WriteMMIO(
         FLETCHER_REG_SCHEMA + 2 * context_->num_recordbatches() + 2 * context_->num_buffers() + i, arguments[i]);
@@ -93,11 +93,11 @@ Status Kernel::GetReturn(uint32_t *ret0, uint32_t *ret1) {
   return status;
 }
 
-Status Kernel::WaitForFinish() {
-  return WaitForFinish(0);
+Status Kernel::PollUntilDone() {
+  return PollUntilDoneInterval(0);
 }
 
-Status Kernel::WaitForFinish(unsigned int poll_interval_usec) {
+Status Kernel::PollUntilDoneInterval(unsigned int poll_interval_usec) {
   bool done = false;
   uint32_t status = 0;
   FLETCHER_LOG(DEBUG, "Polling kernel for completion.");

--- a/runtime/python/pyfletcher/includes/libfletcher.pxd
+++ b/runtime/python/pyfletcher/includes/libfletcher.pxd
@@ -105,5 +105,5 @@ cdef extern from "fletcher/api.h" namespace "fletcher" nogil:
         Status Start()
         Status GetStatus(uint32_t *status)
         Status GetReturn(uint32_t *ret0, uint32_t *ret1)
-        Status WaitForFinish(unsigned int poll_interval_usec)
+        Status PollUntilDoneInterval(unsigned int poll_interval_usec)
         shared_ptr[CContext] context()

--- a/runtime/python/pyfletcher/kernel.pxi
+++ b/runtime/python/pyfletcher/kernel.pxi
@@ -136,14 +136,14 @@ cdef class Kernel:
 
         return cast_scalar.item()
 
-    def wait_for_finish(self, int poll_interval_usec=0):
+    def poll_until_done(self, int poll_interval_usec=0):
         """A blocking function that waits for the Kernel to finish.
 
         Args:
             poll_interval_usec (int): Polling interval in microseconds.
 
         """
-        check_fletcher_status(self.Kernel.get().WaitForFinish(poll_interval_usec))
+        check_fletcher_status(self.Kernel.get().PollUntilDoneInterval(poll_interval_usec))
 
     def get_context(self):
         """Get associated context.


### PR DESCRIPTION
- Fixes #227 

and while fixing it I found it useful to:

- Take MMIO read values in the Echo library, meant for debugging purposes, from stdin
- Rename WaitForFinish() to PollUntilDone(Interval), for a more descriptive API function name